### PR TITLE
Dodaj do leksera obsługę stałych, inkrementacji, dekrementacji, dyrektyw i nazw rejestrów

### DIFF
--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -117,14 +117,22 @@ enum class error_origin : uint8_t
 template <typename T> using result = tl::expected<T, error>;
 
 #define RETURN_IF_ERROR_VOID(expr)                                             \
-    auto __result = (expr);                                                    \
-    if (!__result)                                                             \
     {                                                                          \
-        return tl::make_unexpected(std::move(__result.error()));               \
+        auto __result = (expr);                                                \
+        if (!__result)                                                         \
+        {                                                                      \
+            return tl::make_unexpected(std::move(__result.error()));           \
+        }                                                                      \
     }
 
 #define RETURN_IF_ERROR(out, expr)                                             \
-    RETURN_IF_ERROR_VOID(expr)                                                 \
-    (out) = *__result;
+    {                                                                          \
+        auto __result = (expr);                                                \
+        if (!__result)                                                         \
+        {                                                                      \
+            return tl::make_unexpected(std::move(__result.error()));           \
+        }                                                                      \
+        (out) = std::move(*__result);                                          \
+    }
 
 } // namespace zd

--- a/zdc/include/zd/lexer.hpp
+++ b/zdc/include/zd/lexer.hpp
@@ -10,15 +10,22 @@ class lexer
     pl_istream &_stream;
     token_type  _last_type;
     int         _ch;
+    unsigned    _spaces;
 
   public:
     lexer(pl_istream &stream)
-        : _stream{stream}, _last_type{token_type::line_break}, _ch{}
+        : _stream{stream}, _last_type{token_type::line_break}, _ch{}, _spaces{}
     {
     }
 
     result<token>
     get_token();
+
+    unsigned
+    get_spaces() const
+    {
+        return _spaces;
+    }
 
     enum class error_code : uint8_t
     {

--- a/zdc/include/zd/token.hpp
+++ b/zdc/include/zd/token.hpp
@@ -25,6 +25,7 @@ enum class token_type
     cpref_le,  // &<
     cpref_ge,  // &>
     comment,   // *, Koment, Komentarz
+    directive, // #,, #Autor, #Wstaw, #WstawBin
     compare,   // Porównaj
     constant,  // Stała
     decrement, // Zmniejsz

--- a/zdc/include/zd/token.hpp
+++ b/zdc/include/zd/token.hpp
@@ -28,6 +28,7 @@ enum class token_type
     compare,   // Porównaj
     constant,  // Stała
     end,       // Koniec
+    increment, // Zwiększ
     jump,      // Skok
     procedure, // Procedura
     variable,  // Zmienna

--- a/zdc/include/zd/token.hpp
+++ b/zdc/include/zd/token.hpp
@@ -26,6 +26,7 @@ enum class token_type
     cpref_ge,  // &>
     comment,   // *, Koment, Komentarz
     compare,   // Porównaj
+    constant,  // Stała
     end,       // Koniec
     jump,      // Skok
     procedure, // Procedura

--- a/zdc/include/zd/token.hpp
+++ b/zdc/include/zd/token.hpp
@@ -27,6 +27,7 @@ enum class token_type
     comment,   // *, Koment, Komentarz
     compare,   // Porównaj
     constant,  // Stała
+    decrement, // Zmniejsz
     end,       // Koniec
     increment, // Zwiększ
     jump,      // Skok

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -29,6 +29,7 @@ _match_keyword(const ustring &str)
     RETURN_IF_STREQI(str, "Koment", token_type::comment);
     RETURN_IF_STREQI(str, "Komentarz", token_type::comment);
     RETURN_IF_STREQAI(str, "Porównaj", token_type::compare)
+    RETURN_IF_STREQAI(str, "Stała", token_type::constant)
     RETURN_IF_STREQI(str, "Koniec", token_type::end);
     RETURN_IF_STREQI(str, "Skok", token_type::jump);
     RETURN_IF_STREQI(str, "Procedura", token_type::procedure);

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -31,6 +31,7 @@ _match_keyword(const ustring &str)
     RETURN_IF_STREQAI(str, "Porównaj", token_type::compare)
     RETURN_IF_STREQAI(str, "Stała", token_type::constant)
     RETURN_IF_STREQI(str, "Koniec", token_type::end);
+    RETURN_IF_STREQAI(str, "Zwiększ", token_type::increment);
     RETURN_IF_STREQI(str, "Skok", token_type::jump);
     RETURN_IF_STREQI(str, "Procedura", token_type::procedure);
     RETURN_IF_STREQI(str, "Zmienna", token_type::variable);

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -30,6 +30,7 @@ _match_keyword(const ustring &str)
     RETURN_IF_STREQI(str, "Komentarz", token_type::comment);
     RETURN_IF_STREQAI(str, "Porównaj", token_type::compare)
     RETURN_IF_STREQAI(str, "Stała", token_type::constant)
+    RETURN_IF_STREQI(str, "Zmniejsz", token_type::decrement);
     RETURN_IF_STREQI(str, "Koniec", token_type::end);
     RETURN_IF_STREQAI(str, "Zwiększ", token_type::increment);
     RETURN_IF_STREQI(str, "Skok", token_type::jump);

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -46,6 +46,8 @@ _isnotcrlf(int ch)
 result<token>
 lexer::get_token()
 {
+    _spaces = 0;
+
     if (!_ch)
     {
         RETURN_IF_ERROR(_ch, _stream.read());
@@ -69,6 +71,7 @@ lexer::get_token()
 
     while (_stream && isspace(_ch))
     {
+        _spaces++;
         RETURN_IF_ERROR(_ch, _stream.read());
     }
 

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -41,6 +41,42 @@ _match_keyword(const ustring &str)
 }
 
 static bool
+_is_register(const ustring &str)
+{
+    if (2 != str.size())
+    {
+        return false;
+    }
+
+    int first = str.data()[0], second = str.data()[1];
+    if (!zd::isalpha(first) || !zd::isalpha(second))
+    {
+        return false;
+    }
+
+    first = tolower(first);
+    second = tolower(second);
+
+    if (('a' == first) || ('b' == first) || ('c' == first))
+    {
+        return ('l' == second) || ('h' == second) || ('x' == second);
+    }
+
+    if ('d' == first)
+    {
+        return ('l' == second) || ('h' == second) || ('x' == second) ||
+               ('i' == second);
+    }
+
+    if ('s' == first)
+    {
+        return ('i' == second);
+    }
+
+    return false;
+}
+
+static bool
 _isnotcrlf(int ch)
 {
     return ('\r' != ch) && ('\n' != ch);
@@ -150,8 +186,14 @@ lexer::get_token()
         return token{_last_type, std::move(string)};
     }
 
-    // String literal
+    // String literal or register name
     RETURN_IF_ERROR_VOID(scan_while(string, _isnotcrlf));
+
+    if (_is_register(string))
+    {
+        return token{_last_type = token_type::name, std::move(string)};
+    }
+
     return token{_last_type = token_type::literal_str, std::move(string)};
 }
 

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -171,6 +171,20 @@ lexer::get_token()
     }
 
     ustring string{};
+    if ((token_type::line_break == _last_type) && ('#' == _ch))
+    {
+        // Directive
+        RETURN_IF_ERROR(_ch, _stream.read());
+        if (!isalpha(_ch) && (',' != _ch))
+        {
+            return make_error(error_code::unexpected_character, _ch,
+                              token_type::directive);
+        }
+
+        RETURN_IF_ERROR_VOID(scan_while(string, _isnotcrlf));
+        return token{_last_type = token_type::directive, std::move(string)};
+    }
+
     if ((token_type::name != _last_type) &&
         (token_type::assign != _last_type) && isalpha(_ch))
     {

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -132,7 +132,8 @@ lexer::get_token()
     }
 
     ustring string{};
-    if ((token_type::name != _last_type) && isalpha(_ch))
+    if ((token_type::name != _last_type) &&
+        (token_type::assign != _last_type) && isalpha(_ch))
     {
         // Keyword, verb, or target
         RETURN_IF_ERROR_VOID(scan_while(string, isalnum));

--- a/zdc/src/zd/token.cpp
+++ b/zdc/src/zd/token.cpp
@@ -28,6 +28,7 @@ static const char *ENUM_NAMES[]{
     ENUM_NAME_MAPPING(cpref_ge, "conditional prefix greater or equal"),
     ENUM_NAME_MAPPING(comment, "comment"),
     ENUM_NAME_MAPPING(compare, "compare keyword"),
+    ENUM_NAME_MAPPING(constant, "constant keyword"),
     ENUM_NAME_MAPPING(end, "end keyword"),
     ENUM_NAME_MAPPING(jump, "jump keyword"),
     ENUM_NAME_MAPPING(procedure, "procedure keyword"),

--- a/zdc/src/zd/token.cpp
+++ b/zdc/src/zd/token.cpp
@@ -27,6 +27,7 @@ static const char *ENUM_NAMES[]{
     ENUM_NAME_MAPPING(cpref_le, "conditional prefix less or equal"),
     ENUM_NAME_MAPPING(cpref_ge, "conditional prefix greater or equal"),
     ENUM_NAME_MAPPING(comment, "comment"),
+    ENUM_NAME_MAPPING(directive, "directive"),
     ENUM_NAME_MAPPING(compare, "compare keyword"),
     ENUM_NAME_MAPPING(constant, "constant keyword"),
     ENUM_NAME_MAPPING(decrement, "decrement keyword"),

--- a/zdc/src/zd/token.cpp
+++ b/zdc/src/zd/token.cpp
@@ -30,6 +30,7 @@ static const char *ENUM_NAMES[]{
     ENUM_NAME_MAPPING(compare, "compare keyword"),
     ENUM_NAME_MAPPING(constant, "constant keyword"),
     ENUM_NAME_MAPPING(end, "end keyword"),
+    ENUM_NAME_MAPPING(increment, "increment keyword"),
     ENUM_NAME_MAPPING(jump, "jump keyword"),
     ENUM_NAME_MAPPING(procedure, "procedure keyword"),
     ENUM_NAME_MAPPING(variable, "variable keyword"),

--- a/zdc/src/zd/token.cpp
+++ b/zdc/src/zd/token.cpp
@@ -29,6 +29,7 @@ static const char *ENUM_NAMES[]{
     ENUM_NAME_MAPPING(comment, "comment"),
     ENUM_NAME_MAPPING(compare, "compare keyword"),
     ENUM_NAME_MAPPING(constant, "constant keyword"),
+    ENUM_NAME_MAPPING(decrement, "decrement keyword"),
     ENUM_NAME_MAPPING(end, "end keyword"),
     ENUM_NAME_MAPPING(increment, "increment keyword"),
     ENUM_NAME_MAPPING(jump, "jump keyword"),

--- a/zdc/src/zdc.cpp
+++ b/zdc/src/zdc.cpp
@@ -33,7 +33,8 @@ main(int argc, char *argv[])
             break;
         }
 
-        std::printf("\t%-16s", zd::to_string(token->get_type()).data());
+        std::printf("\t%-3u %-16s", lexer.get_spaces(),
+                    zd::to_string(token->get_type()).data());
         if (zd::token_type::eof == token->get_type())
         {
             break;


### PR DESCRIPTION
Ogólne:
- pozwalaj na wielokrotne użycie `RETURN_IF_ERROR` z różnymi typami w jednym zasięgu

Lekser (poziom lek-07):
- zliczaj spacje poprzedzające token
- obsłuż literały tekstowe w przypisaniu
- obsłuż słowa kluczowe `Stała`, `Zwiększ`, i `Zmniejsz`
- obsłuż nazwy rejestrów w wywołaniach
- obsłuż dyrektywy