### PR TITLE
Dodaj do leksera obsługę indeksu i literałów szesnastkowych

### DIFF
--- a/zdc/include/zd/characters.hpp
+++ b/zdc/include/zd/characters.hpp
@@ -31,6 +31,12 @@ isdigit(int ch)
 }
 
 static inline bool
+isxdigit(int ch)
+{
+    return isascii(ch) && std::isxdigit(ch);
+}
+
+static inline bool
 isalnum(int ch)
 {
     return isalpha(ch) || isdigit(ch);

--- a/zdc/include/zd/lexer.hpp
+++ b/zdc/include/zd/lexer.hpp
@@ -11,10 +11,12 @@ class lexer
     token_type  _last_type;
     int         _ch;
     unsigned    _spaces;
+    ustring     _head;
 
   public:
     lexer(pl_istream &stream)
-        : _stream{stream}, _last_type{token_type::line_break}, _ch{}, _spaces{}
+        : _stream{stream}, _last_type{token_type::line_break}, _ch{}, _spaces{},
+          _head{}
     {
     }
 
@@ -36,6 +38,9 @@ class lexer
   private:
     result<void>
     scan_while(ustring &out, bool (*predicate)(int));
+
+    result<token>
+    process_string();
 
     static tl::unexpected<error>
     make_error(error_code code)

--- a/zdc/include/zd/token.hpp
+++ b/zdc/include/zd/token.hpp
@@ -18,7 +18,7 @@ enum class token_type
     byval,     // %
     byref,     // $
     assign,    // =
-    cpref_eq,  // &
+    ampersand, // &
     cpref_lt,  // <
     cpref_gt,  // >
     cpref_ne,  // <>

--- a/zdc/include/zd/token.hpp
+++ b/zdc/include/zd/token.hpp
@@ -24,6 +24,7 @@ enum class token_type
     cpref_ne,  // <>
     cpref_le,  // &<
     cpref_ge,  // &>
+    subscript, // #
     comment,   // *, Koment, Komentarz
     directive, // #,, #Autor, #Wstaw, #WstawBin
     compare,   // Porównaj

--- a/zdc/include/zd/ustring.hpp
+++ b/zdc/include/zd/ustring.hpp
@@ -124,6 +124,9 @@ class ustring
     bool
     append(int codepoint);
 
+    void
+    clear();
+
     friend bool
     operator==(const ustring &left, const ustring &right);
 

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -158,7 +158,7 @@ lexer::get_token()
         RETURN_IF_ERROR(_ch, _stream.read());
         RETURN_IF_CHTOKEN('<', {_last_type = token_type::cpref_le});
         RETURN_IF_CHTOKEN('>', {_last_type = token_type::cpref_ge});
-        return {_last_type = token_type::cpref_eq};
+        return {_last_type = token_type::ampersand};
     }
 
     if ((token_type::line_break == _last_type) && ('*' == _ch))

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -171,21 +171,22 @@ lexer::get_token()
     }
 
     ustring string{};
-    if ((token_type::line_break == _last_type) && ('#' == _ch))
+    if ('#' == _ch)
     {
-        // Directive
+        // Directive or subscript
         RETURN_IF_ERROR(_ch, _stream.read());
         if (!isalpha(_ch) && (',' != _ch))
         {
-            return make_error(error_code::unexpected_character, _ch,
-                              token_type::directive);
+            // Subscript
+            return token(token_type::subscript);
         }
 
+        // Directive
         RETURN_IF_ERROR_VOID(scan_while(string, _isnotcrlf));
         return token{_last_type = token_type::directive, std::move(string)};
     }
 
-    if ((token_type::name != _last_type) &&
+    if ((token_type::name != _last_type) && (token_type::comma != _last_type) &&
         (token_type::assign != _last_type) && isalpha(_ch))
     {
         // Keyword, verb, or target

--- a/zdc/src/zd/token.cpp
+++ b/zdc/src/zd/token.cpp
@@ -20,7 +20,7 @@ static const char *ENUM_NAMES[]{
     ENUM_NAME_MAPPING(byval, "access by value"),
     ENUM_NAME_MAPPING(byref, "access by reference"),
     ENUM_NAME_MAPPING(assign, "assignment"),
-    ENUM_NAME_MAPPING(cpref_eq, "conditional prefix equal"),
+    ENUM_NAME_MAPPING(ampersand, "ampersand"),
     ENUM_NAME_MAPPING(cpref_lt, "conditional prefix less than"),
     ENUM_NAME_MAPPING(cpref_gt, "conditional prefix greater than"),
     ENUM_NAME_MAPPING(cpref_ne, "conditional prefix not equal"),

--- a/zdc/src/zd/token.cpp
+++ b/zdc/src/zd/token.cpp
@@ -26,6 +26,7 @@ static const char *ENUM_NAMES[]{
     ENUM_NAME_MAPPING(cpref_ne, "conditional prefix not equal"),
     ENUM_NAME_MAPPING(cpref_le, "conditional prefix less or equal"),
     ENUM_NAME_MAPPING(cpref_ge, "conditional prefix greater or equal"),
+    ENUM_NAME_MAPPING(subscript, "subscript"),
     ENUM_NAME_MAPPING(comment, "comment"),
     ENUM_NAME_MAPPING(directive, "directive"),
     ENUM_NAME_MAPPING(compare, "compare keyword"),

--- a/zdc/src/zd/ustring.cpp
+++ b/zdc/src/zd/ustring.cpp
@@ -118,6 +118,16 @@ ustring::append(int codepoint)
     return true;
 }
 
+void
+ustring::clear()
+{
+    _size = 0;
+    if (_data)
+    {
+        *_data = 0;
+    }
+}
+
 bool
 zd::operator==(const ustring &left, const ustring &right)
 {


### PR DESCRIPTION
Ogólne:
- dodaj metodę czyszczenia `ustring` bez zwalniania pamięci

Lekser (poziom lek-09):
- obsłuż operator indeksu (`#`)
- obsłuż szesnastkowe literały liczbowe (`$...`)
- przemień *przedrostek warunkowy równe* na *ampersand*