### PR TITLE
Dodaj do leksera obsługę etykiet zaczynających się cyfrą oraz końcowych spacji

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | MYSZ | ✅ |
 | SAVER | ✅ |
 | **PRZYKLAD** | - |
-| DOWCIPY | |
+| DOWCIPY | ✅ |
 | GRA | |
 | KWADRAT | |
 | LINIA | |

--- a/README.md
+++ b/README.md
@@ -37,22 +37,22 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | SAVER | ✅ |
 | **PRZYKLAD** | - |
 | DOWCIPY | ✅ |
-| GRA | |
-| KWADRAT | |
-| LINIA | |
-| PETLE | |
-| ZC | |
-| !TLO | |
-| ALARM | |
-| ASCII | |
-| COOL-GR1 | |
-| DEMO | |
-| DZWIEK | |
-| EFEKT | |
-| LOSOWE | |
-| MYSZ | |
-| MYSZKA | |
-| MYSZRYS | |
+| GRA | ✅ |
+| KWADRAT | ✅ |
+| LINIA | ✅ |
+| PETLE | ✅ |
+| ZC | ✅ |
+| !TLO | ✅ |
+| ALARM | ✅ |
+| ASCII | ✅ |
+| COOL-GR1 | ✅ |
+| DEMO | ✅ |
+| DZWIEK | ✅ |
+| EFEKT | ✅ |
+| LOSOWE | ✅ |
+| MYSZ | ✅ |
+| MYSZKA | ✅ |
+| MYSZRYS | ✅ |
 | PARAMETR | |
 | PLIKI1 | |
 | PLIKI2 | |

--- a/zdc/include/zd/characters.hpp
+++ b/zdc/include/zd/characters.hpp
@@ -45,7 +45,7 @@ isalnum(int ch)
 static inline bool
 isspace(int ch)
 {
-    return isascii(ch) && std::isspace(ch);
+    return (' ' == ch) || ('\t' == ch);
 }
 
 static inline bool

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -221,6 +221,12 @@ lexer::get_token()
                 return token{_last_type = token_type::byref};
             }
 
+            if (token_type::colon == _last_type)
+            {
+                // :3Opcja is a valid label in ZDZICH4
+                return std::move(process_string());
+            }
+
             return make_error(error_code::unexpected_character, _ch,
                               token_type::literal_int);
         }
@@ -258,7 +264,9 @@ lexer::process_string()
         return token{_last_type = token_type::directive, std::move(string)};
     }
 
-    if (_allows_name_after(_last_type) && is_name_start(_ch))
+    if (_allows_name_after(_last_type) &&
+        ((token_type::colon == _last_type) ? is_name_continuation(_ch)
+                                           : is_name_start(_ch)))
     {
         // Keyword, verb, or target
         RETURN_IF_ERROR_VOID(scan_while(string, is_name_continuation));


### PR DESCRIPTION
Lekser (zgodność: !TLO, ALARM, ASCII, COOL-GR1, DEMO, DOWCIPY, DZWIEK, EFEKT, GRA, KWADRAT, LINIA, LOSOWE, MYSZ, MYSZKA, MYSZRYS, PETLE, ZC):
- obsłuż etykiety zaczynające się cyfrą, np. `:3Chata`
- nie traktuj nowej linii jako spacji, np. w wywołaniu `Pisz` z samymi spacjami