### PR TITLE
Dodaj do leksera obsługę plusów i minusów

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | MYSZ | ✅ |
 | MYSZKA | ✅ |
 | MYSZRYS | ✅ |
-| PARAMETR | |
-| PLIKI1 | |
-| PLIKI2 | |
-| SKOKI | |
+| PARAMETR | ✅ |
+| PLIKI1 | ✅ |
+| PLIKI2 | ✅ |
+| SKOKI | ✅ |
 | TESTMYSZ | |
 | WSTAW | |

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | PLIKI1 | ✅ |
 | PLIKI2 | ✅ |
 | SKOKI | ✅ |
-| TESTMYSZ | |
-| WSTAW | |
+| TESTMYSZ | ✅ |
+| WSTAW | ✅ |

--- a/zdc/include/zd/token.hpp
+++ b/zdc/include/zd/token.hpp
@@ -18,6 +18,8 @@ enum class token_type
     byval,     // %
     byref,     // $
     assign,    // =
+    plus,      // +
+    minus,     // -
     ampersand, // &
     cpref_lt,  // <
     cpref_gt,  // >

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -157,6 +157,8 @@ lexer::get_token()
     RETURN_IF_CHTOKEN(')', {_last_type = token_type::rbracket});
     RETURN_IF_CHTOKEN('%', {_last_type = token_type::byval});
     RETURN_IF_CHTOKEN('=', {_last_type = token_type::assign});
+    RETURN_IF_CHTOKEN('+', {_last_type = token_type::plus});
+    RETURN_IF_CHTOKEN('-', {_last_type = token_type::minus});
 
     // Conditional prefixes
     RETURN_IF_CHTOKEN('>', {_last_type = token_type::cpref_gt});

--- a/zdc/src/zd/lexer.cpp
+++ b/zdc/src/zd/lexer.cpp
@@ -157,8 +157,25 @@ lexer::get_token()
     RETURN_IF_CHTOKEN(')', {_last_type = token_type::rbracket});
     RETURN_IF_CHTOKEN('%', {_last_type = token_type::byval});
     RETURN_IF_CHTOKEN('=', {_last_type = token_type::assign});
-    RETURN_IF_CHTOKEN('+', {_last_type = token_type::plus});
-    RETURN_IF_CHTOKEN('-', {_last_type = token_type::minus});
+
+    if (('+' == _ch) || ('-' == _ch))
+    {
+        // Plus sign, minus sign, or a string literal made of them
+        _head.append(_ch);
+        RETURN_IF_ERROR(_ch, _stream.read());
+
+        if (('+' == _ch) || ('-' == _ch))
+        {
+            // A string literal (keep head)
+            return std::move(process_string());
+        }
+
+        // A single character!
+        token_type type =
+            ('+' == *_head.data()) ? token_type::plus : token_type::minus;
+        _head.clear();
+        return {_last_type = type};
+    }
 
     // Conditional prefixes
     RETURN_IF_CHTOKEN('>', {_last_type = token_type::cpref_gt});

--- a/zdc/src/zd/token.cpp
+++ b/zdc/src/zd/token.cpp
@@ -20,6 +20,8 @@ static const char *ENUM_NAMES[]{
     ENUM_NAME_MAPPING(byval, "access by value"),
     ENUM_NAME_MAPPING(byref, "access by reference"),
     ENUM_NAME_MAPPING(assign, "assignment"),
+    ENUM_NAME_MAPPING(plus, "plus sign"),
+    ENUM_NAME_MAPPING(minus, "minus sign"),
     ENUM_NAME_MAPPING(ampersand, "ampersand"),
     ENUM_NAME_MAPPING(cpref_lt, "conditional prefix less than"),
     ENUM_NAME_MAPPING(cpref_gt, "conditional prefix greater than"),


### PR DESCRIPTION
Lekser (zgodność: PARAMETR, PLIKI1, PLIKI2, SKOKI, TESTMYSZ, WSTAW):
- obsłuż znaki plus i minus
- obsłuż literały składające się z plusów lub minusów