### PR TITLE
Parsuj przykłady z folderu „PRZYKLAD”

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | MYSZ | ✅ | ✅ |
 | SAVER | ✅ | ✅ |
 | **PRZYKLAD** | - | - |
-| DOWCIPY | ✅ |
+| DOWCIPY | ✅ | ✅ |
 | GRA | ✅ |
 | KWADRAT | ✅ |
 | LINIA | ✅ |

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | MYSZ | ✅ | ✅ |
 | MYSZKA | ✅ | ✅ |
 | MYSZRYS | ✅ | ✅ |
-| PARAMETR | ✅ |
-| PLIKI1 | ✅ |
-| PLIKI2 | ✅ |
-| SKOKI | ✅ |
-| TESTMYSZ | ✅ |
-| WSTAW | ✅ |
+| PARAMETR | ✅ | ✅ |
+| PLIKI1 | ✅ | ✅ |
+| PLIKI2 | ✅ | ✅ |
+| SKOKI | ✅ | ✅ |
+| TESTMYSZ | ✅ | ✅ |
+| WSTAW | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | LEKCJA11 | ✅ | ✅ |
 | ZADANIA | ✅ | ✅ |
 | **INC** | - | - |
-| DOGIER | ✅ |
-| DZWIEK | ✅ |
-| DZWIEK2 | ✅ |
-| KLAWIAT | ✅ |
-| MYSZ | ✅ |
+| DOGIER | ✅ | ✅ |
+| DZWIEK | ✅ | ✅ |
+| DZWIEK2 | ✅ | ✅ |
+| KLAWIAT | ✅ | ✅ |
+| MYSZ | ✅ | ✅ |
 | SAVER | ✅ |
 | **PRZYKLAD** | - | - |
 | DOWCIPY | ✅ |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | DZWIEK2 | ✅ | ✅ |
 | KLAWIAT | ✅ | ✅ |
 | MYSZ | ✅ | ✅ |
-| SAVER | ✅ |
+| SAVER | ✅ | ✅ |
 | **PRZYKLAD** | - | - |
 | DOWCIPY | ✅ |
 | GRA | ✅ |

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | SAVER | ✅ | ✅ |
 | **PRZYKLAD** | - | - |
 | DOWCIPY | ✅ | ✅ |
-| GRA | ✅ |
-| KWADRAT | ✅ |
-| LINIA | ✅ |
-| PETLE | ✅ |
+| GRA | ✅ | ✅ |
+| KWADRAT | ✅ | ✅ |
+| LINIA | ✅ | ✅ |
+| PETLE | ✅ | ✅ |
 | ZC | ✅ |
 | !TLO | ✅ |
 | ALARM | ✅ |

--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | KWADRAT | ✅ | ✅ |
 | LINIA | ✅ | ✅ |
 | PETLE | ✅ | ✅ |
-| ZC | ✅ |
-| !TLO | ✅ |
-| ALARM | ✅ |
-| ASCII | ✅ |
-| COOL-GR1 | ✅ |
-| DEMO | ✅ |
-| DZWIEK | ✅ |
-| EFEKT | ✅ |
-| LOSOWE | ✅ |
-| MYSZ | ✅ |
-| MYSZKA | ✅ |
-| MYSZRYS | ✅ |
+| ZC | ✅ | ✅ |
+| !TLO | ✅ | ✅ |
+| ALARM | ✅ | ✅ |
+| ASCII | ✅ | ✅ |
+| COOL-GR1 | ✅ | ✅ |
+| DEMO | ✅ | ✅ |
+| DZWIEK | ✅ | ✅ |
+| EFEKT | ✅ | ✅ |
+| LOSOWE | ✅ | ✅ |
+| MYSZ | ✅ | ✅ |
+| MYSZKA | ✅ | ✅ |
+| MYSZRYS | ✅ | ✅ |
 | PARAMETR | ✅ |
 | PLIKI1 | ✅ |
 | PLIKI2 | ✅ |

--- a/zdc/include/zd/gen/generator.hpp
+++ b/zdc/include/zd/gen/generator.hpp
@@ -12,6 +12,7 @@ struct condition_node;
 struct declaration_node;
 struct end_node;
 struct emit_node;
+struct include_node;
 struct jump_node;
 struct label_node;
 struct number_node;
@@ -47,6 +48,9 @@ struct generator
 
     virtual bool
     process(const par::emit_node &node) = 0;
+
+    virtual bool
+    process(const par::include_node &node) = 0;
 
     virtual bool
     process(const par::jump_node &node) = 0;

--- a/zdc/include/zd/gen/text_generator.hpp
+++ b/zdc/include/zd/gen/text_generator.hpp
@@ -38,6 +38,9 @@ class text_generator : public generator
     process(const par::emit_node &node) override;
 
     bool
+    process(const par::include_node &node) override;
+
+    bool
     process(const par::jump_node &node) override;
 
     bool

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -44,6 +44,7 @@ enum class operation
 static const uint16_t cpu_register_lbyte = 0x0000;
 static const uint16_t cpu_register_hbyte = 0x0100;
 static const uint16_t cpu_register_word = 0x0200;
+static const uint16_t cpu_register_flag = 0xFF00;
 
 enum class cpu_register : uint16_t
 {
@@ -54,6 +55,9 @@ enum class cpu_register : uint16_t
     d,
     src,
     dst,
+    flag_c = cpu_register_flag,
+    flag_d,
+    flag_i,
     al = a | cpu_register_lbyte,
     bl = b | cpu_register_lbyte,
     cl = c | cpu_register_lbyte,

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -112,9 +112,10 @@ struct call_node : public node
 {
     const ustring   callee;
     const node_list arguments;
+    const bool      is_bare;
 
-    call_node(const ustring &callee_, node_list arguments_)
-        : callee{callee_}, arguments{std::move(arguments_)}
+    call_node(const ustring &callee_, node_list arguments_, bool is_bare_)
+        : callee{callee_}, arguments{std::move(arguments_)}, is_bare{is_bare_}
     {
     }
 

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -172,6 +172,19 @@ struct end_node : public node
     IMPLEMENT_GENERATOR_ACCESS;
 };
 
+struct include_node : public node
+{
+    const ustring name;
+    const bool    is_binary;
+
+    include_node(const ustring &name_, bool is_binary_ = false)
+        : name{name_}, is_binary{is_binary_}
+    {
+    }
+
+    IMPLEMENT_GENERATOR_ACCESS;
+};
+
 struct jump_node : public node
 {
     const unique_node target;

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -263,6 +263,8 @@ struct string_node : public node
 {
     const ustring value;
 
+    string_node() = default;
+
     string_node(const ustring &value_) : value{value_}
     {
     }

--- a/zdc/include/zd/par/parser.hpp
+++ b/zdc/include/zd/par/parser.hpp
@@ -29,6 +29,7 @@ class parser
         unknown_directive = 3,
         out_of_range = 4,
         name_expected = 5,
+        include_expected = 6,
     };
 
   private:

--- a/zdc/include/zd/par/parser.hpp
+++ b/zdc/include/zd/par/parser.hpp
@@ -37,7 +37,7 @@ class parser
                       ustring         name = ustring{});
 
     result<unique_node>
-    handle_call(const ustring &callee);
+    handle_call(const ustring &callee, bool enclosed = false);
 
     result<unique_node>
     handle_condition(lex::token_type   ttype,

--- a/zdc/include/zd/par/parser.hpp
+++ b/zdc/include/zd/par/parser.hpp
@@ -28,6 +28,7 @@ class parser
         unexpected_eof = 2,
         unknown_directive = 3,
         out_of_range = 4,
+        name_expected = 5,
     };
 
   private:
@@ -96,6 +97,14 @@ class parser
         return tl::make_unexpected(
             error{static_cast<uint8_t>(error_origin::parser),
                   static_cast<uint8_t>(code), to_cstr(ttype)});
+    }
+
+    static tl::unexpected<error>
+    make_error(error_code code, lex::token_type context, lex::token_type ttype)
+    {
+        return tl::make_unexpected(error{
+            static_cast<uint8_t>(error_origin::parser),
+            static_cast<uint8_t>(code), to_cstr(context), to_cstr(ttype)});
     }
 
     static tl::unexpected<error>

--- a/zdc/include/zd/ustring.hpp
+++ b/zdc/include/zd/ustring.hpp
@@ -37,6 +37,12 @@ class ustring
             return old;
         }
 
+        const pointer
+        get() const
+        {
+            return _ptr;
+        }
+
         friend bool
         operator==(const iterator &left, const iterator &right)
         {

--- a/zdc/src/messages.cpp
+++ b/zdc/src/messages.cpp
@@ -55,6 +55,8 @@ const struct _msg
      "number %d is out of range"},
     {make_id(error_origin::parser, par::parser::error_code::name_expected),
      "name expected after '%s', got '%s'"},
+    {make_id(error_origin::parser, par::parser::error_code::include_expected),
+     "include path expected"},
 };
 
 static const char *

--- a/zdc/src/messages.cpp
+++ b/zdc/src/messages.cpp
@@ -53,6 +53,8 @@ const struct _msg
      "unknown directive"},
     {make_id(error_origin::parser, par::parser::error_code::out_of_range),
      "number %d is out of range"},
+    {make_id(error_origin::parser, par::parser::error_code::name_expected),
+     "name expected after '%s', got '%s'"},
 };
 
 static const char *

--- a/zdc/src/zd/gen/text_generator.cpp
+++ b/zdc/src/zd/gen/text_generator.cpp
@@ -140,6 +140,19 @@ text_generator::process(const end_node &node)
 }
 
 bool
+text_generator::process(const include_node &node)
+{
+    if (node.is_binary)
+    {
+        std::fprintf(_out, "<include binary %s>", node.name.data());
+        return true;
+    }
+
+    std::fprintf(_out, "<include %s>", node.name.data());
+    return true;
+}
+
+bool
 text_generator::process(const jump_node &node)
 {
     std::fputs("<jump ", _out);

--- a/zdc/src/zd/gen/text_generator.cpp
+++ b/zdc/src/zd/gen/text_generator.cpp
@@ -108,6 +108,12 @@ bool
 text_generator::process(const declaration_node &node)
 {
     std::fputs("<declaration ", _out);
+
+    if (node.is_const)
+    {
+        std::fputs("const ", _out);
+    }
+
     node.target->generate(this);
     std::fputc('>', _out);
     return true;
@@ -178,7 +184,7 @@ text_generator::process(const number_node &node)
 bool
 text_generator::process(const object_node &node)
 {
-    std::fprintf(_out, "<variable %s:", node.name.data());
+    std::fprintf(_out, "<object %s:", node.name.data());
 
     switch (node.type)
     {

--- a/zdc/src/zd/gen/text_generator.cpp
+++ b/zdc/src/zd/gen/text_generator.cpp
@@ -225,8 +225,18 @@ text_generator::process(const register_node &node)
 {
     std::fputs("<register ", _out);
 
-    std::fputc("ABCDSD"[(static_cast<uint16_t>(node.reg) & 0xFF) - 1], _out);
-    switch (static_cast<uint16_t>(node.reg) & 0xFF00)
+    auto size = static_cast<uint16_t>(node.reg) & 0xFF00;
+    if (size == cpu_register_flag)
+    {
+        std::fputc("CDI"[(static_cast<uint16_t>(node.reg) & 0xFF)], _out);
+    }
+    else
+    {
+        std::fputc("ABCDSD"[(static_cast<uint16_t>(node.reg) & 0xFF) - 1],
+                   _out);
+    }
+
+    switch (size)
     {
     case cpu_register_lbyte:
         std::fputc('L', _out);
@@ -242,6 +252,10 @@ text_generator::process(const register_node &node)
                 ? 'I'
                 : 'X',
             _out);
+        break;
+
+    case cpu_register_flag:
+        std::fputs("FLAG", _out);
         break;
     }
 

--- a/zdc/src/zd/gen/text_generator.cpp
+++ b/zdc/src/zd/gen/text_generator.cpp
@@ -24,6 +24,11 @@ text_generator::process(const call_node &node)
     std::fputs("<call ", _out);
     std::fputs(node.callee.data(), _out);
 
+    if (node.is_bare)
+    {
+        std::fputs(" bare", _out);
+    }
+
     for (auto &argument : node.arguments)
     {
         std::fputc(' ', _out);

--- a/zdc/src/zd/lex/lexer.cpp
+++ b/zdc/src/zd/lex/lexer.cpp
@@ -178,13 +178,16 @@ lex::lexer::get_token()
     }
 
     // Conditional prefixes
-    RETURN_IF_CHTOKEN('>', {_last_type = token_type::cpref_gt});
-
-    if ('<' == _ch)
+    if (token_type::line_break == _last_type)
     {
-        RETURN_IF_ERROR(_ch, _stream.read());
-        RETURN_IF_CHTOKEN('>', {_last_type = token_type::cpref_ne});
-        return {_last_type = token_type::cpref_lt};
+        RETURN_IF_CHTOKEN('>', {_last_type = token_type::cpref_gt});
+
+        if ('<' == _ch)
+        {
+            RETURN_IF_ERROR(_ch, _stream.read());
+            RETURN_IF_CHTOKEN('>', {_last_type = token_type::cpref_ne});
+            return {_last_type = token_type::cpref_lt};
+        }
     }
 
     if ('&' == _ch)

--- a/zdc/src/zd/lex/lexer.cpp
+++ b/zdc/src/zd/lex/lexer.cpp
@@ -144,7 +144,7 @@ lex::lexer::get_token()
         return {_last_type = token_type::line_break};
     }
 
-    while (_stream && isspace(_ch))
+    while (_stream && text::isspace(_ch))
     {
         _spaces++;
         RETURN_IF_ERROR(_ch, _stream.read());
@@ -218,7 +218,7 @@ lex::lexer::get_token()
         // Not sure yet, pass through
     }
 
-    auto isbdigit = (16 == base) ? isxdigit : isdigit;
+    auto isbdigit = (16 == base) ? text::isxdigit : text::isdigit;
     if (isbdigit(_ch))
     {
         // Integer literal

--- a/zdc/src/zd/lex/lexer.cpp
+++ b/zdc/src/zd/lex/lexer.cpp
@@ -158,7 +158,7 @@ lex::lexer::get_token()
     RETURN_IF_CHTOKEN('%', {_last_type = token_type::byval});
     RETURN_IF_CHTOKEN('=', {_last_type = token_type::assign});
 
-    if (('+' == _ch) || ('-' == _ch))
+    if ((token_type::name == _last_type) && (('+' == _ch) || ('-' == _ch)))
     {
         // Plus sign, minus sign, or a string literal made of them
         _head.append(_ch);

--- a/zdc/src/zd/par/parser.cpp
+++ b/zdc/src/zd/par/parser.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cctype>
 #include <cstdio>
 
@@ -423,6 +424,43 @@ par::parser::handle_declaration(bool is_const)
 result<par::unique_node>
 par::parser::handle_directive(const ustring &directive)
 {
+    auto name_end =
+        std::find_if(directive.begin(), directive.end(), text::isspace);
+    if (directive.end() != name_end)
+    {
+        ustring name{};
+        std::for_each(directive.begin(), name_end, [&name](int ch) {
+            name.append(ch);
+        });
+
+        if (text::pl_streqi("Wstaw", name))
+        {
+            // #Wstaw
+            auto path_begin =
+                std::find_if_not(name_end, directive.end(), text::isspace);
+            if (directive.end() == path_begin)
+            {
+                return make_error(error_code::include_expected);
+            }
+
+            return std::make_unique<include_node>(path_begin.get());
+        }
+
+        if (text::pl_streqi("WstawBin", name))
+        {
+            // #WstawBin
+            auto path_begin =
+                std::find_if_not(name_end, directive.end(), text::isspace);
+            if (directive.end() == path_begin)
+            {
+                return make_error(error_code::include_expected);
+            }
+
+            return std::make_unique<include_node>(path_begin.get(), true);
+        }
+    }
+
+    // #,
     auto it = directive.begin();
     if (',' != *it)
     {

--- a/zdc/src/zd/par/parser.cpp
+++ b/zdc/src/zd/par/parser.cpp
@@ -216,11 +216,10 @@ par::parser::handle_assignment(lex::token_type ttype,
 }
 
 result<par::unique_node>
-par::parser::handle_call(const ustring &callee)
+par::parser::handle_call(const ustring &callee, bool enclosed)
 {
     node_list  arguments{};
     bool       bare{true};
-    bool       enclosed{false};
     bool       more{true};
     lex::token token{};
 
@@ -431,6 +430,15 @@ par::parser::handle_end()
     case lex::token_type::name:
         name = token.get_text();
         break;
+
+    // SAVER.INC:51 - Koniec KONIEC()
+    case lex::token_type::end:
+        name = "Koniec";
+        break;
+
+    // SAVER.INC:45 - KONIEC()
+    case lex::token_type::lbracket:
+        return handle_call("Koniec", true);
 
     case lex::token_type::eof:
     case lex::token_type::line_break:

--- a/zdc/src/zd/par/parser.cpp
+++ b/zdc/src/zd/par/parser.cpp
@@ -27,6 +27,26 @@ _to_cpu_register(const ustring &str)
     par::cpu_register reg{};
 
     auto it = str.begin();
+
+    if (1 == str.size())
+    {
+        // Flags
+        switch (std::toupper(*it))
+        {
+        case 'C':
+            return par::cpu_register::flag_c;
+
+        case 'D':
+            return par::cpu_register::flag_d;
+
+        case 'I':
+            return par::cpu_register::flag_i;
+        }
+
+        return par::cpu_register::invalid;
+    }
+
+    // General purpose register
     switch (std::toupper(*it++))
     {
     case 'A':
@@ -204,8 +224,23 @@ par::parser::handle_assignment(lex::token_type ttype,
     lex::token token{};
 
     RETURN_IF_ERROR(token, _lexer.get_token());
-    if (lex::token_type::assign != token.get_type())
+    switch (token.get_type())
     {
+    case lex::token_type::minus:
+        // Boolean disable
+        return std::make_unique<assignment_node>(
+            std::move(target), std::make_unique<number_node>(0));
+
+    case lex::token_type::plus:
+        // Boolean enable
+        return std::make_unique<assignment_node>(
+            std::move(target), std::make_unique<number_node>(1));
+
+    case lex::token_type::assign:
+        // A regular assignment
+        break;
+
+    default:
         return make_error(error_code::unexpected_token, token.get_type());
     }
 

--- a/zdc/src/zd/par/parser.cpp
+++ b/zdc/src/zd/par/parser.cpp
@@ -219,6 +219,7 @@ result<par::unique_node>
 par::parser::handle_call(const ustring &callee)
 {
     node_list  arguments{};
+    bool       bare{true};
     bool       enclosed{false};
     bool       more{true};
     lex::token token{};
@@ -235,6 +236,7 @@ par::parser::handle_call(const ustring &callee)
                 if (!enclosed && to_cstr(lex::token_type::lbracket) == tts)
                 {
                     // Opening bracket
+                    bare = false;
                     enclosed = true;
                     continue;
                 }
@@ -257,6 +259,7 @@ par::parser::handle_call(const ustring &callee)
             break;
         }
 
+        bare = false;
         RETURN_IF_ERROR(token, _lexer.get_token());
         switch (token.get_type())
         {
@@ -314,7 +317,7 @@ par::parser::handle_call(const ustring &callee)
         }
     }
 
-    return std::make_unique<call_node>(callee, std::move(arguments));
+    return std::make_unique<call_node>(callee, std::move(arguments), bare);
 }
 
 result<par::unique_node>

--- a/zdc/src/zd/ustring.cpp
+++ b/zdc/src/zd/ustring.cpp
@@ -121,6 +121,11 @@ ustring::append(int codepoint)
 bool
 ustring::append(const ustring &tail)
 {
+    if (!tail._size)
+    {
+        return true;
+    }
+
     if (!reserve(_size + tail._size))
     {
         return false;


### PR DESCRIPTION
Ogólne:
- obsłuż dopisywanie pustego `ustring`

Lekser:
- ogranicz rozpoznawanie `+` i `-`
- popraw wykorzystanie `isdigit`, `isspace` i `isxdigit` (zgodność: DOWCIPY)
- ogranicz rozpoznawanie `<`, `>` i `<>` (zgodność: GRA, KWADRAT, LINIA, PETLE)

Parser:
- rozróżnij wywołania z nawiasami i bez nich (zgodność: DOGIER, DZWIEK, DZWIEK2, KLAWIAT, MYSZ)
- obsłuż `Koniec` w roli nazwy procedury (zgodność: SAVER)
- obsłuż literały tekstowe składające się wyłącznie z `&`, `%`, `$` i spacji
- obsłuż literały tekstowe zaczynające się cyfrą i nawiasem zamykającym
- obsłuż dyrektywy `#Wstaw` i `#WstawBin` (zgodność: ZC, !TLO, ALARM, ASCII, COOL-GR1, DEMO, DZWIEK, EFEKT, LOSOWE, MYSZ, MYSZKA, MYSZRYS)
- obsłuż ustawianie flag, np. `D-` (zgodność: PARAMETR, PLIKI1, PLIKI2, SKOKI, TESTMYSZ, WSTAW)

Generator tekstowy:
- popraw opisy deklaracji stałych (`<declaration const`)
- popraw opisy użycia obiektów (`variable` -> `object`)