### PR TITLE
Dodaj obsługę załączania plików źródłowych

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(Zdzich CXX)
+project(Zdzich CXX C)
 
 # Compiler dependent tweaks
 if(MSVC)
@@ -12,8 +12,8 @@ if(DOS)
     add_compile_options(-mcmodel=small)
     add_compile_options(-mnewlib-nano-stdio)
     add_compile_options(-Os)
-    add_compile_options(-fno-exceptions)
-    add_compile_options(-fno-rtti)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 
     add_link_options(-mcmodel=small)
     add_link_options(-mnewlib-nano-stdio)

--- a/tools/mconv.py
+++ b/tools/mconv.py
@@ -1,0 +1,119 @@
+import re
+import sys
+
+from argparse import ArgumentParser, FileType
+from io import TextIOWrapper
+from typing import Generator
+
+
+# Regular expressions for formatting specifiers
+RE_WINFMT = re.compile(
+    r"%(\d+)!([-\+# ]*\d*\.?\d*(hh|ll|I32|I64|[hjlLtwzI])?[cCdiouxXeEfFgGaAnpsSZ])!")
+RE_LOWER_S = re.compile(r"(%\d+\$[-\+# ]*\d*\.?\d*)s")
+RE_UPPER_S = re.compile(r"(%\d+\$[-\+# ]*\d*\.?\d*)S")
+RE_POS = re.compile(r"%(\d+)\$")
+
+
+# Parse an assignemnt into a key-value paur
+def get_assignment(line: str) -> tuple[str, str]:
+    key, value = line.rstrip().split("=", 1)
+    if value.startswith("(") and value.endswith(")"):
+        value = value[1:-1]
+
+    return key, value
+
+
+# Load all messages from a MC file
+def get_messages(input: TextIOWrapper) -> Generator[tuple[int, int, str], None, None]:
+    languages = dict()
+
+    message_id = str()
+    message_language = int()
+    message_text = str()
+
+    for line in input:
+        if line.startswith((";", "\n")):
+            continue
+
+        if line.rstrip() == ".":
+            yield message_id, message_language, message_text.rstrip()
+            message_text = str()
+            continue
+
+        if re.match("^\w+=", line):
+            key, value = get_assignment(line)
+            if key == "LanguageNames":
+                lang_name, details = get_assignment(value)
+                languages[lang_name] = int(details.split(":")[0], 0)
+            if key == "MessageId":
+                message_id = int(value, 0)
+            if key == "Language":
+                message_language = languages[value]
+            continue
+
+        message_text += line
+
+
+# Convert MSVC positional specifiers to POSIX syntax
+def to_posix_fmt(winfmt: str) -> str:
+    posfmt = RE_WINFMT.sub(r"%\1$\2", winfmt)
+    posfmt = RE_LOWER_S.sub(r"\1ls", posfmt)
+    posfmt = RE_UPPER_S.sub(r"\1s", posfmt)
+    return posfmt
+
+
+# Strip positional specifiers
+def to_ansi_fmt(posfmt: str) -> str:
+    assert is_nano_compatible(posfmt)
+    return RE_POS.sub("%", posfmt)
+
+
+# Check if there's no position change
+def is_nano_compatible(fmt: str) -> bool:
+    for i, pos in enumerate(RE_POS.findall(fmt), 1):
+        if i != int(pos):
+            return False
+
+    return True
+
+
+# Escape backslashes, double quotes, new lines
+def escape_string(string: str) -> str:
+    ret = str(string)
+    for old, new in [
+        ("\\", "\\\\"),
+        ("\"", "\\\""),
+        ("\n", "\\n"),
+    ]:
+        ret = ret.replace(old, new)
+    return ret
+
+
+# Parse command line arguments
+parser = ArgumentParser(description="Utility for converting Message Compiler text files into C language",
+                        epilog="Copyright (c) 2024 Mateusz Karcz. MIT Licensed.")
+
+parser.add_argument("input", type=FileType(
+    encoding="utf-8-sig"), help="Message Compiler input text file")
+parser.add_argument(
+    "lcid", type=int, help="LCID of the language to be extracted")
+parser.add_argument("-o", type=FileType("w", encoding="utf-8"), dest="output", default=sys.stdout,
+                    help="output C file (stdout is the default)")
+
+args = parser.parse_args()
+
+# Create the declaration
+print("const struct { unsigned id; const char *msg; }", file=args.output)
+print(f"MESSAGES_{args.lcid:04X}[] = {{", file=args.output)
+
+# Convert all messages filtered by LCID to C language
+for id, lang, text in get_messages(args.input):
+    if lang != args.lcid:
+        continue
+
+    converted = escape_string(to_ansi_fmt(to_posix_fmt(text)))
+    print(f"{{0x{id:04X}, \"{converted}\"}},", file=args.output)
+
+# Write the footer
+print("{0, 0}", file=args.output)
+print("};", file=args.output)

--- a/zdc/CMakeLists.txt
+++ b/zdc/CMakeLists.txt
@@ -23,6 +23,20 @@ if(WIN32)
 
 	set_source_files_properties(zdc.rc PROPERTIES GENERATED TRUE)
 	target_sources(zdc PRIVATE zdc.rc)
+else()
+	add_custom_command(
+		OUTPUT zdc_en_US.c
+		COMMAND python3
+		ARGS
+			${CMAKE_CURRENT_SOURCE_DIR}/../tools/mconv.py
+			-o ${CMAKE_CURRENT_BINARY_DIR}/zdc_en_US.c
+			${CMAKE_CURRENT_SOURCE_DIR}/src/zdc.mc
+			1033
+		MAIN_DEPENDENCY
+			${CMAKE_CURRENT_SOURCE_DIR}/src/zdc.mc)
+
+	set_source_files_properties(zdc_en_US.c PROPERTIES GENERATED TRUE)
+	target_sources(zdc PRIVATE zdc_en_US.c)
 endif()
 
 install(TARGETS zdc DESTINATION .)

--- a/zdc/CMakeLists.txt
+++ b/zdc/CMakeLists.txt
@@ -9,4 +9,20 @@ if(DOS)
     target_link_options(zdc PRIVATE -Wl,--Map=zdc.map)
 endif()
 
+if(WIN32)
+	add_custom_command(
+		OUTPUT zdc.rc zdc.h
+			zdc_en_US.bin
+		COMMAND mc.exe
+		ARGS
+			-h ${CMAKE_CURRENT_BINARY_DIR}
+			-r ${CMAKE_CURRENT_BINARY_DIR}
+			-n ${CMAKE_CURRENT_SOURCE_DIR}/src/zdc.mc
+		MAIN_DEPENDENCY
+			${CMAKE_CURRENT_SOURCE_DIR}/src/zdc.mc)
+
+	set_source_files_properties(zdc.rc PROPERTIES GENERATED TRUE)
+	target_sources(zdc PRIVATE zdc.rc)
+endif()
+
 install(TARGETS zdc DESTINATION .)

--- a/zdc/include/zd/containers.hpp
+++ b/zdc/include/zd/containers.hpp
@@ -22,6 +22,23 @@ get_index(const Container &container, const T &value)
            std::begin(container);
 }
 
+template <typename InputIt, typename UnaryPred>
+inline InputIt
+find_last_if(InputIt first, InputIt last, UnaryPred p)
+{
+    auto ret = last;
+
+    for (auto it = first; it != last; it++)
+    {
+        if (p(*it))
+        {
+            ret = it;
+        }
+    }
+
+    return ret;
+}
+
 template <typename T> class range
 {
     const T     *_items;

--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -18,6 +18,8 @@ class error
     uint8_t    _origin;
     uint8_t    _ordinal;
     ustring    _file;
+    unsigned   _line;
+    unsigned   _column;
     size_t     _argc;
     uintptr_t *_argv;
 
@@ -50,9 +52,13 @@ class error
     }
 
   public:
-    error(uint8_t origin, uint8_t ordinal, ustring file)
-        : _origin{origin}, _ordinal{ordinal}, _file{std::move(file)}, _argc{0},
-          _argv{nullptr}
+    error(uint8_t  origin,
+          uint8_t  ordinal,
+          ustring  file,
+          unsigned line,
+          unsigned column)
+        : _origin{origin}, _ordinal{ordinal}, _file{std::move(file)},
+          _line{line}, _column{column}, _argc{0}, _argv{nullptr}
     {
     }
 
@@ -60,7 +66,8 @@ class error
 
     error(error &&that) noexcept
         : _origin{that._origin}, _ordinal{that._ordinal},
-          _file{std::move(that._file)}, _argc{std::exchange(that._argc, 0)},
+          _file{std::move(that._file)}, _line{that._line},
+          _column{that._column}, _argc{std::exchange(that._argc, 0)},
           _argv{std::exchange(that._argv, nullptr)}
     {
     }
@@ -88,6 +95,18 @@ class error
         return _file;
     }
 
+    unsigned
+    line() const
+    {
+        return _line;
+    }
+
+    unsigned
+    column() const
+    {
+        return _column;
+    }
+
     size_t
     size() const
     {
@@ -110,9 +129,14 @@ class error
     }
 
     template <typename... Args>
-    error(uint8_t origin, uint8_t ordinal, ustring file, Args... args)
+    error(uint8_t  origin,
+          uint8_t  ordinal,
+          ustring  file,
+          unsigned line,
+          unsigned column,
+          Args... args)
         : _origin{origin}, _ordinal{ordinal}, _file{std::move(file)},
-          _argc{sizeof...(args)},
+          _line{line}, _column{column}, _argc{sizeof...(args)},
           _argv{new(std::nothrow) uintptr_t[sizeof...(args)]}
     {
         to_argv(_argv, args...);

--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -8,6 +8,8 @@
 #include <new>
 #include <utility>
 
+#include <zd/ustring.hpp>
+
 namespace zd
 {
 
@@ -15,6 +17,7 @@ class error
 {
     uint8_t    _origin;
     uint8_t    _ordinal;
+    ustring    _file;
     size_t     _argc;
     uintptr_t *_argv;
 
@@ -47,8 +50,9 @@ class error
     }
 
   public:
-    error(uint8_t origin, uint8_t ordinal)
-        : _origin{origin}, _ordinal{ordinal}, _argc{0}, _argv{nullptr}
+    error(uint8_t origin, uint8_t ordinal, ustring file)
+        : _origin{origin}, _ordinal{ordinal}, _file{std::move(file)}, _argc{0},
+          _argv{nullptr}
     {
     }
 
@@ -56,7 +60,7 @@ class error
 
     error(error &&that) noexcept
         : _origin{that._origin}, _ordinal{that._ordinal},
-          _argc{std::exchange(that._argc, 0)},
+          _file{std::move(that._file)}, _argc{std::exchange(that._argc, 0)},
           _argv{std::exchange(that._argv, nullptr)}
     {
     }
@@ -76,6 +80,12 @@ class error
     ordinal() const
     {
         return _ordinal;
+    }
+
+    const ustring &
+    file() const
+    {
+        return _file;
     }
 
     size_t
@@ -100,8 +110,9 @@ class error
     }
 
     template <typename... Args>
-    error(uint8_t origin, uint8_t ordinal, Args... args)
-        : _origin{origin}, _ordinal{ordinal}, _argc{sizeof...(args)},
+    error(uint8_t origin, uint8_t ordinal, ustring file, Args... args)
+        : _origin{origin}, _ordinal{ordinal}, _file{std::move(file)},
+          _argc{sizeof...(args)},
           _argv{new(std::nothrow) uintptr_t[sizeof...(args)]}
     {
         to_argv(_argv, args...);

--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -76,6 +76,21 @@ class error
         to_argv(argv + 1, tail...);
     }
 
+    template <typename Head>
+    inline static void
+    to_argvfp(uintptr_t *argvfp, Head head)
+    {
+        *argvfp = 0;
+    }
+
+    template <typename Head, typename... Tail>
+    inline static void
+    to_argvfp(uintptr_t *argvfp, Head head, Tail... tail)
+    {
+        to_argvfp(argvfp, head);
+        to_argvfp(argvfp + 1, tail...);
+    }
+
   public:
     template <typename Torigin, typename Traits = error_origin_traits<Torigin>>
     error(const Torigin &origin, typename Traits::ordinal_type code)
@@ -95,9 +110,10 @@ class error
         : error{origin, code}
     {
         _argc = sizeof...(args);
-        _argv = new (std::nothrow) uintptr_t[sizeof...(args)];
+        _argv = new (std::nothrow) uintptr_t[sizeof...(args) * 2];
 
         to_argv(_argv, args...);
+        to_argvfp(_argv + sizeof...(args), args...);
     }
 
     error(const error &) = delete;

--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -168,7 +168,7 @@ class error
 
     template <typename Torigin, typename Traits = error_origin_traits<Torigin>>
     inline bool
-    is(typename Traits::ordinal_type ord)
+    is(typename Traits::ordinal_type ord) const
     {
         return (static_cast<uint8_t>(Traits::origin_tag) == origin()) &&
                (static_cast<uint8_t>(ord) == ordinal());

--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -166,11 +166,11 @@ class error
         return _argv + _argc;
     }
 
-    template <typename Torig, typename Tord>
+    template <typename Torigin, typename Traits = error_origin_traits<Torigin>>
     inline bool
-    is(Torig orig, Tord ord)
+    is(typename Traits::ordinal_type ord)
     {
-        return (static_cast<uint8_t>(orig) == origin()) &&
+        return (static_cast<uint8_t>(Traits::origin_tag) == origin()) &&
                (static_cast<uint8_t>(ord) == ordinal());
     }
 };

--- a/zdc/include/zd/io/min_istream.hpp
+++ b/zdc/include/zd/io/min_istream.hpp
@@ -14,24 +14,27 @@ namespace io
 class min_istream
 {
     std::FILE *_file;
+    ustring    _path;
 
   public:
-    min_istream() noexcept : _file{nullptr}
+    min_istream() noexcept : _file{nullptr}, _path{}
     {
     }
 
-    min_istream(std::FILE *file) noexcept : _file{file}
+    min_istream(std::FILE *file) noexcept : _file{file}, _path{}
     {
     }
 
-    min_istream(const ustring &name) noexcept : _file{fopen(name.data(), "rb")}
+    min_istream(const ustring &name) noexcept
+        : _file{fopen(name.data(), "rb")}, _path{name}
     {
     }
 
     min_istream(const min_istream &) = delete;
 
     min_istream(min_istream &&that) noexcept
-        : _file{std::exchange(that._file, nullptr)}
+        : _file{std::exchange(that._file, nullptr)},
+          _path{std::move(that._path)}
     {
     }
 
@@ -47,6 +50,7 @@ class min_istream
         }
 
         _file = std::exchange(that._file, nullptr);
+        _path = std::move(that._path);
         return *this;
     }
 
@@ -63,6 +67,12 @@ class min_istream
     get() const noexcept
     {
         return _file;
+    }
+
+    const ustring &
+    get_path() const
+    {
+        return _path;
     }
 
     operator bool() const noexcept

--- a/zdc/include/zd/lex/lexer.hpp
+++ b/zdc/include/zd/lex/lexer.hpp
@@ -53,6 +53,8 @@ class lexer
         return _spaces;
     }
 
+    static const auto error_origin_tag = error_origin::lexer;
+
     enum class error_code : uint8_t
     {
         invalid_newline = 0,
@@ -72,18 +74,14 @@ class lexer
     tl::unexpected<error>
     make_error(error_code code)
     {
-        return tl::make_unexpected(error{
-            static_cast<uint8_t>(error_origin::lexer),
-            static_cast<uint8_t>(code), get_path(), get_line(), get_column()});
+        return tl::make_unexpected(error{*this, code});
     }
 
     tl::unexpected<error>
     make_error(error_code code, int character, token_type ttype)
     {
         return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::lexer),
-                  static_cast<uint8_t>(code), get_path(), get_line(),
-                  get_column(), character, to_cstr(ttype)});
+            error{*this, code, character, to_cstr(ttype)});
     }
 };
 

--- a/zdc/include/zd/lex/lexer.hpp
+++ b/zdc/include/zd/lex/lexer.hpp
@@ -53,20 +53,20 @@ class lexer
     result<token>
     process_string();
 
-    static tl::unexpected<error>
+    tl::unexpected<error>
     make_error(error_code code)
     {
         return tl::make_unexpected(
             error{static_cast<uint8_t>(error_origin::lexer),
-                  static_cast<uint8_t>(code)});
+                  static_cast<uint8_t>(code), get_path()});
     }
 
-    static tl::unexpected<error>
+    tl::unexpected<error>
     make_error(error_code code, int character, token_type ttype)
     {
-        return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::lexer),
-                  static_cast<uint8_t>(code), character, to_cstr(ttype)});
+        return tl::make_unexpected(error{
+            static_cast<uint8_t>(error_origin::lexer),
+            static_cast<uint8_t>(code), get_path(), character, to_cstr(ttype)});
     }
 };
 

--- a/zdc/include/zd/lex/lexer.hpp
+++ b/zdc/include/zd/lex/lexer.hpp
@@ -31,6 +31,18 @@ class lexer
         return _stream.get_path();
     }
 
+    unsigned
+    get_line() const
+    {
+        return _stream.get_line();
+    }
+
+    unsigned
+    get_column() const
+    {
+        return _stream.get_column();
+    }
+
     result<token>
     get_token();
 
@@ -56,17 +68,18 @@ class lexer
     tl::unexpected<error>
     make_error(error_code code)
     {
-        return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::lexer),
-                  static_cast<uint8_t>(code), get_path()});
+        return tl::make_unexpected(error{
+            static_cast<uint8_t>(error_origin::lexer),
+            static_cast<uint8_t>(code), get_path(), get_line(), get_column()});
     }
 
     tl::unexpected<error>
     make_error(error_code code, int character, token_type ttype)
     {
-        return tl::make_unexpected(error{
-            static_cast<uint8_t>(error_origin::lexer),
-            static_cast<uint8_t>(code), get_path(), character, to_cstr(ttype)});
+        return tl::make_unexpected(
+            error{static_cast<uint8_t>(error_origin::lexer),
+                  static_cast<uint8_t>(code), get_path(), get_line(),
+                  get_column(), character, to_cstr(ttype)});
     }
 };
 

--- a/zdc/include/zd/lex/lexer.hpp
+++ b/zdc/include/zd/lex/lexer.hpp
@@ -25,6 +25,12 @@ class lexer
     {
     }
 
+    const ustring &
+    get_path() const
+    {
+        return _stream.get_path();
+    }
+
     result<token>
     get_token();
 

--- a/zdc/include/zd/lex/lexer.hpp
+++ b/zdc/include/zd/lex/lexer.hpp
@@ -13,6 +13,7 @@ namespace lex
 class lexer
 {
     pl_istream &_stream;
+    unsigned    _column;
     token_type  _last_type;
     int         _ch;
     unsigned    _spaces;
@@ -20,8 +21,8 @@ class lexer
 
   public:
     lexer(pl_istream &stream)
-        : _stream{stream}, _last_type{token_type::line_break}, _ch{}, _spaces{},
-          _head{}
+        : _stream{stream}, _last_type{token_type::line_break}, _column{0},
+          _ch{}, _spaces{}, _head{}
     {
     }
 
@@ -40,7 +41,7 @@ class lexer
     unsigned
     get_column() const
     {
-        return _stream.get_column();
+        return _column;
     }
 
     result<token>
@@ -59,6 +60,9 @@ class lexer
     };
 
   private:
+    result<void>
+    read();
+
     result<void>
     scan_while(ustring &out, bool (*predicate)(int));
 

--- a/zdc/include/zd/lex/lexer.hpp
+++ b/zdc/include/zd/lex/lexer.hpp
@@ -26,6 +26,12 @@ class lexer
     {
     }
 
+    const pl_istream &
+    get_stream() const
+    {
+        return _stream;
+    }
+
     const ustring &
     get_path() const
     {

--- a/zdc/include/zd/lex/pl_istream.hpp
+++ b/zdc/include/zd/lex/pl_istream.hpp
@@ -42,6 +42,12 @@ class pl_istream
         return _encoding;
     }
 
+    const ustring &
+    get_path() const
+    {
+        return _stream.get_path();
+    }
+
     enum class error_code : uint8_t
     {
         unexpected_byte = 0,

--- a/zdc/include/zd/lex/pl_istream.hpp
+++ b/zdc/include/zd/lex/pl_istream.hpp
@@ -14,17 +14,19 @@ class pl_istream
 {
     io::min_istream _stream;
     text::encoding *_encoding;
+    unsigned        _line;
+    unsigned        _column;
 
   public:
     pl_istream(io::min_istream &&stream,
                text::encoding   *enc = text::encoding::unknown)
-        : _stream{std::move(stream)}, _encoding{enc}
+        : _stream{std::move(stream)}, _encoding{enc}, _line{1}, _column{1}
     {
     }
 
     pl_istream(const ustring  &name,
                text::encoding *enc = text::encoding::unknown) noexcept
-        : _stream{name}, _encoding{enc}
+        : _stream{name}, _encoding{enc}, _line{1}, _column{1}
     {
     }
 
@@ -48,6 +50,18 @@ class pl_istream
         return _stream.get_path();
     }
 
+    unsigned
+    get_line() const
+    {
+        return _line;
+    }
+
+    unsigned
+    get_column() const
+    {
+        return _column;
+    }
+
     enum class error_code : uint8_t
     {
         unexpected_byte = 0,
@@ -59,9 +73,9 @@ class pl_istream
     tl::unexpected<error>
     make_error(error_code code)
     {
-        return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::stream),
-                  static_cast<uint8_t>(code), get_path()});
+        return tl::make_unexpected(error{
+            static_cast<uint8_t>(error_origin::stream),
+            static_cast<uint8_t>(code), get_path(), get_line(), get_column()});
     }
 
     tl::unexpected<error>
@@ -69,7 +83,8 @@ class pl_istream
     {
         return tl::make_unexpected(
             error{static_cast<uint8_t>(error_origin::stream),
-                  static_cast<uint8_t>(code), get_path(), byte, encoding});
+                  static_cast<uint8_t>(code), get_path(), get_line(),
+                  get_column(), byte, encoding});
     }
 };
 

--- a/zdc/include/zd/lex/pl_istream.hpp
+++ b/zdc/include/zd/lex/pl_istream.hpp
@@ -56,20 +56,20 @@ class pl_istream
     };
 
   private:
-    static tl::unexpected<error>
+    tl::unexpected<error>
     make_error(error_code code)
     {
         return tl::make_unexpected(
             error{static_cast<uint8_t>(error_origin::stream),
-                  static_cast<uint8_t>(code)});
+                  static_cast<uint8_t>(code), get_path()});
     }
 
-    static tl::unexpected<error>
+    tl::unexpected<error>
     make_error(error_code code, char byte, const char *encoding)
     {
         return tl::make_unexpected(
             error{static_cast<uint8_t>(error_origin::stream),
-                  static_cast<uint8_t>(code), byte, encoding});
+                  static_cast<uint8_t>(code), get_path(), byte, encoding});
     }
 };
 

--- a/zdc/include/zd/lex/pl_istream.hpp
+++ b/zdc/include/zd/lex/pl_istream.hpp
@@ -62,6 +62,8 @@ class pl_istream
         return _column;
     }
 
+    static const auto error_origin_tag = error_origin::stream;
+
     enum class error_code : uint8_t
     {
         unexpected_byte = 0,
@@ -73,18 +75,13 @@ class pl_istream
     tl::unexpected<error>
     make_error(error_code code)
     {
-        return tl::make_unexpected(error{
-            static_cast<uint8_t>(error_origin::stream),
-            static_cast<uint8_t>(code), get_path(), get_line(), get_column()});
+        return tl::make_unexpected(error{*this, code});
     }
 
     tl::unexpected<error>
     make_error(error_code code, char byte, const char *encoding)
     {
-        return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::stream),
-                  static_cast<uint8_t>(code), get_path(), get_line(),
-                  get_column(), byte, encoding});
+        return tl::make_unexpected(error{*this, code, byte, encoding});
     }
 };
 

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -181,6 +181,10 @@ struct include_node : public node
     const ustring name;
     const bool    is_binary;
 
+    include_node() : name{}, is_binary{false}
+    {
+    }
+
     include_node(const ustring &name_, bool is_binary_ = false)
         : name{name_}, is_binary{is_binary_}
     {

--- a/zdc/include/zd/par/parser.hpp
+++ b/zdc/include/zd/par/parser.hpp
@@ -84,36 +84,37 @@ class parser
     result<unique_node>
     handle_value();
 
-    static tl::unexpected<error>
+    tl::unexpected<error>
     make_error(error_code code)
     {
         return tl::make_unexpected(
             error{static_cast<uint8_t>(error_origin::parser),
-                  static_cast<uint8_t>(code)});
+                  static_cast<uint8_t>(code), _lexer.get_path()});
     }
 
-    static tl::unexpected<error>
+    tl::unexpected<error>
     make_error(error_code code, lex::token_type ttype)
-    {
-        return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::parser),
-                  static_cast<uint8_t>(code), to_cstr(ttype)});
-    }
-
-    static tl::unexpected<error>
-    make_error(error_code code, lex::token_type context, lex::token_type ttype)
     {
         return tl::make_unexpected(error{
             static_cast<uint8_t>(error_origin::parser),
-            static_cast<uint8_t>(code), to_cstr(context), to_cstr(ttype)});
+            static_cast<uint8_t>(code), _lexer.get_path(), to_cstr(ttype)});
     }
 
-    static tl::unexpected<error>
+    tl::unexpected<error>
+    make_error(error_code code, lex::token_type context, lex::token_type ttype)
+    {
+        return tl::make_unexpected(
+            error{static_cast<uint8_t>(error_origin::parser),
+                  static_cast<uint8_t>(code), _lexer.get_path(),
+                  to_cstr(context), to_cstr(ttype)});
+    }
+
+    tl::unexpected<error>
     make_error(error_code code, int number)
     {
         return tl::make_unexpected(
             error{static_cast<uint8_t>(error_origin::parser),
-                  static_cast<uint8_t>(code), number});
+                  static_cast<uint8_t>(code), _lexer.get_path(), number});
     }
 };
 

--- a/zdc/include/zd/par/parser.hpp
+++ b/zdc/include/zd/par/parser.hpp
@@ -89,24 +89,26 @@ class parser
     {
         return tl::make_unexpected(
             error{static_cast<uint8_t>(error_origin::parser),
-                  static_cast<uint8_t>(code), _lexer.get_path()});
+                  static_cast<uint8_t>(code), _lexer.get_path(),
+                  _lexer.get_line(), _lexer.get_column()});
     }
 
     tl::unexpected<error>
     make_error(error_code code, lex::token_type ttype)
     {
-        return tl::make_unexpected(error{
-            static_cast<uint8_t>(error_origin::parser),
-            static_cast<uint8_t>(code), _lexer.get_path(), to_cstr(ttype)});
+        return tl::make_unexpected(
+            error{static_cast<uint8_t>(error_origin::parser),
+                  static_cast<uint8_t>(code), _lexer.get_path(),
+                  _lexer.get_line(), _lexer.get_column(), to_cstr(ttype)});
     }
 
     tl::unexpected<error>
     make_error(error_code code, lex::token_type context, lex::token_type ttype)
     {
-        return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::parser),
-                  static_cast<uint8_t>(code), _lexer.get_path(),
-                  to_cstr(context), to_cstr(ttype)});
+        return tl::make_unexpected(error{
+            static_cast<uint8_t>(error_origin::parser),
+            static_cast<uint8_t>(code), _lexer.get_path(), _lexer.get_line(),
+            _lexer.get_column(), to_cstr(context), to_cstr(ttype)});
     }
 
     tl::unexpected<error>
@@ -114,7 +116,8 @@ class parser
     {
         return tl::make_unexpected(
             error{static_cast<uint8_t>(error_origin::parser),
-                  static_cast<uint8_t>(code), _lexer.get_path(), number});
+                  static_cast<uint8_t>(code), _lexer.get_path(),
+                  _lexer.get_line(), _lexer.get_column(), number});
     }
 };
 

--- a/zdc/include/zd/par/parser.hpp
+++ b/zdc/include/zd/par/parser.hpp
@@ -49,7 +49,9 @@ class parser
         unknown_directive = 3,
         out_of_range = 4,
         name_expected = 5,
-        include_expected = 6,
+        path_expected = 6,
+        not_a_command = 7,
+        cannot_emit = 8,
     };
 
   private:
@@ -114,6 +116,12 @@ class parser
     make_error(error_code code, lex::token_type ttype)
     {
         return tl::make_unexpected(error{*this, code, to_cstr(ttype)});
+    }
+
+    tl::unexpected<error>
+    make_error(error_code code, lex::token_type ttype, const char *str)
+    {
+        return tl::make_unexpected(error{*this, code, to_cstr(ttype), str});
     }
 
     tl::unexpected<error>

--- a/zdc/include/zd/par/parser.hpp
+++ b/zdc/include/zd/par/parser.hpp
@@ -18,8 +18,28 @@ class parser
     {
     }
 
+    const ustring &
+    get_path() const
+    {
+        return _lexer.get_path();
+    }
+
+    unsigned
+    get_line() const
+    {
+        return _lexer.get_line();
+    }
+
+    unsigned
+    get_column() const
+    {
+        return _lexer.get_column();
+    }
+
     result<unique_node>
     handle(const lex::token &head = lex::token{});
+
+    static const auto error_origin_tag = error_origin::parser;
 
     enum class error_code : uint8_t
     {
@@ -87,37 +107,26 @@ class parser
     tl::unexpected<error>
     make_error(error_code code)
     {
-        return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::parser),
-                  static_cast<uint8_t>(code), _lexer.get_path(),
-                  _lexer.get_line(), _lexer.get_column()});
+        return tl::make_unexpected(error{*this, code});
     }
 
     tl::unexpected<error>
     make_error(error_code code, lex::token_type ttype)
     {
-        return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::parser),
-                  static_cast<uint8_t>(code), _lexer.get_path(),
-                  _lexer.get_line(), _lexer.get_column(), to_cstr(ttype)});
+        return tl::make_unexpected(error{*this, code, to_cstr(ttype)});
     }
 
     tl::unexpected<error>
     make_error(error_code code, lex::token_type context, lex::token_type ttype)
     {
-        return tl::make_unexpected(error{
-            static_cast<uint8_t>(error_origin::parser),
-            static_cast<uint8_t>(code), _lexer.get_path(), _lexer.get_line(),
-            _lexer.get_column(), to_cstr(context), to_cstr(ttype)});
+        return tl::make_unexpected(
+            error{*this, code, to_cstr(context), to_cstr(ttype)});
     }
 
     tl::unexpected<error>
     make_error(error_code code, int number)
     {
-        return tl::make_unexpected(
-            error{static_cast<uint8_t>(error_origin::parser),
-                  static_cast<uint8_t>(code), _lexer.get_path(),
-                  _lexer.get_line(), _lexer.get_column(), number});
+        return tl::make_unexpected(error{*this, code, number});
     }
 };
 

--- a/zdc/include/zd/ustring.hpp
+++ b/zdc/include/zd/ustring.hpp
@@ -43,16 +43,16 @@ class ustring
             return _ptr;
         }
 
-        friend bool
-        operator==(const iterator &left, const iterator &right)
+        bool
+        operator==(const iterator &that)
         {
-            return left._ptr == right._ptr;
+            return _ptr == that._ptr;
         };
 
-        friend bool
-        operator!=(const iterator &left, const iterator &right)
+        bool
+        operator!=(const iterator &that)
         {
-            return left._ptr != right._ptr;
+            return _ptr != that._ptr;
         };
 
       private:
@@ -145,13 +145,13 @@ class ustring
     void
     clear();
 
-    friend bool
-    operator==(const ustring &left, const ustring &right);
+    bool
+    operator==(const ustring &that);
 
-    friend bool
-    operator!=(const ustring &left, const ustring &right)
+    bool
+    operator!=(const ustring &that)
     {
-        return !(left == right);
+        return !(*this == that);
     }
 };
 

--- a/zdc/include/zd/ustring.hpp
+++ b/zdc/include/zd/ustring.hpp
@@ -125,6 +125,14 @@ class ustring
         return _data;
     }
 
+    char *
+    extract()
+    {
+        _size = 0;
+        _capacity = 0;
+        return std::exchange(_data, nullptr);
+    }
+
     bool
     reserve(size_t new_cap);
 

--- a/zdc/src/messages.cpp
+++ b/zdc/src/messages.cpp
@@ -7,6 +7,10 @@
 #include <zd/lex/pl_istream.hpp>
 #include <zd/par/parser.hpp>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
@@ -21,6 +25,7 @@ make_id(Torig origin, Tord ordinal)
            static_cast<uint16_t>(ordinal);
 }
 
+#ifndef _WIN32
 const struct _msg
 {
     uint16_t    id;
@@ -83,6 +88,7 @@ retrieve_fmt(uint8_t origin, uint8_t ordinal)
     case num:                                                                  \
         std::fprintf(stderr, (fmt), ARGV##num(argv));                          \
         break;
+#endif
 
 void
 print_error(const error &err)
@@ -90,6 +96,22 @@ print_error(const error &err)
     auto path = err.file().empty() ? "input" : err.file().data();
     std::fprintf(stderr, "%s:%u:%u: error: ", path, err.line(), err.column());
 
+#ifdef _WIN32
+    auto args =
+        reinterpret_cast<DWORD_PTR *>(const_cast<uintptr_t *>(err.begin()));
+    LPWSTR buffer{nullptr};
+    DWORD  length = ::FormatMessageW(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_ARGUMENT_ARRAY |
+            FORMAT_MESSAGE_FROM_HMODULE,
+        nullptr, make_id(err.origin(), err.ordinal()),
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        reinterpret_cast<LPWSTR>(&buffer), 0,
+        reinterpret_cast<va_list *>(args));
+    ::WriteConsoleW(::GetStdHandle(STD_ERROR_HANDLE), buffer, length, NULL,
+                    NULL);
+    ::LocalFree(buffer);
+
+#else
     if (auto fmt = retrieve_fmt(err.origin(), err.ordinal()))
     {
         switch (err.size())
@@ -99,7 +121,8 @@ print_error(const error &err)
         default:
             std::fputs(fmt, stderr);
         }
-
-        std::fputs("\n", stderr);
     }
+#endif
+
+    std::fputs("\n", stderr);
 }

--- a/zdc/src/messages.cpp
+++ b/zdc/src/messages.cpp
@@ -84,7 +84,7 @@ void
 print_error(const error &err)
 {
     auto path = err.file().empty() ? "input" : err.file().data();
-    std::fprintf(stderr, "%s: error: ", path);
+    std::fprintf(stderr, "%s:%u:%u: error: ", path, err.line(), err.column());
 
     if (auto fmt = retrieve_fmt(err.origin(), err.ordinal()))
     {

--- a/zdc/src/messages.cpp
+++ b/zdc/src/messages.cpp
@@ -83,6 +83,9 @@ retrieve_fmt(uint8_t origin, uint8_t ordinal)
 void
 print_error(const error &err)
 {
+    auto path = err.file().empty() ? "input" : err.file().data();
+    std::fprintf(stderr, "%s: error: ", path);
+
     if (auto fmt = retrieve_fmt(err.origin(), err.ordinal()))
     {
         switch (err.size())

--- a/zdc/src/messages.cpp
+++ b/zdc/src/messages.cpp
@@ -40,13 +40,13 @@ const struct _msg
     {make_id(error_origin::lexer, lex::lexer::error_code::invalid_newline),
      "invalid line break"},
     {make_id(error_origin::lexer, lex::lexer::error_code::unexpected_character),
-     "unexpected character %d in a token '%s'"},
+     "unexpected character %d in '%s'"},
 
     // Parser
     {make_id(error_origin::parser, par::parser::error_code::eof),
      "end of file"},
     {make_id(error_origin::parser, par::parser::error_code::unexpected_token),
-     "unexpected token '%s'"},
+     "unexpected '%s' in '%s'"},
     {make_id(error_origin::parser, par::parser::error_code::unexpected_eof),
      "unexpected end of file while processing '%s'"},
     {make_id(error_origin::parser, par::parser::error_code::unknown_directive),
@@ -55,8 +55,12 @@ const struct _msg
      "number %d is out of range"},
     {make_id(error_origin::parser, par::parser::error_code::name_expected),
      "name expected after '%s', got '%s'"},
-    {make_id(error_origin::parser, par::parser::error_code::include_expected),
+    {make_id(error_origin::parser, par::parser::error_code::path_expected),
      "include path expected"},
+    {make_id(error_origin::parser, par::parser::error_code::not_a_command),
+     "unexpected '%s' at the beginning of a command"},
+    {make_id(error_origin::parser, par::parser::error_code::cannot_emit),
+     "unexpected character %u in the emit directive"},
 };
 
 static const char *

--- a/zdc/src/zd/error.cpp
+++ b/zdc/src/zd/error.cpp
@@ -21,6 +21,7 @@ error::operator=(error &&that) noexcept
     this->~error();
     _origin = that._origin;
     _ordinal = that._ordinal;
+    _file = std::move(that._file);
     _argc = std::exchange(that._argc, 0);
     _argv = std::exchange(that._argv, nullptr);
     return *this;

--- a/zdc/src/zd/error.cpp
+++ b/zdc/src/zd/error.cpp
@@ -22,6 +22,8 @@ error::operator=(error &&that) noexcept
     _origin = that._origin;
     _ordinal = that._ordinal;
     _file = std::move(that._file);
+    _line = that._line;
+    _column = that._column;
     _argc = std::exchange(that._argc, 0);
     _argv = std::exchange(that._argv, nullptr);
     return *this;

--- a/zdc/src/zd/error.cpp
+++ b/zdc/src/zd/error.cpp
@@ -4,10 +4,24 @@ using namespace zd;
 
 error::~error()
 {
-    if (_argv)
+    if (!_argv)
     {
-        delete[] _argv;
+        return;
     }
+
+    // Call all argument finalizers
+    for (auto it = _argv; it < _argv + _argc; it++)
+    {
+        auto finalizer = reinterpret_cast<void (*)(uintptr_t)>(it[_argc]);
+        if (finalizer)
+        {
+            finalizer(*it);
+        }
+    }
+
+    // Destroy the buffer
+    delete[] _argv;
+    _argv = nullptr;
 }
 
 error &

--- a/zdc/src/zd/lex/lexer.cpp
+++ b/zdc/src/zd/lex/lexer.cpp
@@ -125,7 +125,7 @@ lex::lexer::get_token()
 
     if (!_ch)
     {
-        RETURN_IF_ERROR(_ch, _stream.read());
+        RETURN_IF_ERROR_VOID(read());
     }
 
     if (!_stream || (EOF == _ch))
@@ -147,7 +147,7 @@ lex::lexer::get_token()
     while (_stream && text::isspace(_ch))
     {
         _spaces++;
-        RETURN_IF_ERROR(_ch, _stream.read());
+        RETURN_IF_ERROR_VOID(read());
     }
 
     // Single-character tokens
@@ -162,7 +162,7 @@ lex::lexer::get_token()
     {
         // Plus sign, minus sign, or a string literal made of them
         _head.append(_ch);
-        RETURN_IF_ERROR(_ch, _stream.read());
+        RETURN_IF_ERROR_VOID(read());
 
         if (('+' == _ch) || ('-' == _ch))
         {
@@ -184,7 +184,7 @@ lex::lexer::get_token()
 
         if ('<' == _ch)
         {
-            RETURN_IF_ERROR(_ch, _stream.read());
+            RETURN_IF_ERROR_VOID(read());
             RETURN_IF_CHTOKEN('>', {_last_type = token_type::cpref_ne});
             return {_last_type = token_type::cpref_lt};
         }
@@ -192,7 +192,7 @@ lex::lexer::get_token()
 
     if ('&' == _ch)
     {
-        RETURN_IF_ERROR(_ch, _stream.read());
+        RETURN_IF_ERROR_VOID(read());
         RETURN_IF_CHTOKEN('<', {_last_type = token_type::cpref_le});
         RETURN_IF_CHTOKEN('>', {_last_type = token_type::cpref_ge});
         return {_last_type = token_type::ampersand};
@@ -210,7 +210,7 @@ lex::lexer::get_token()
     if ('$' == _ch)
     {
         // Either reference access or a hexadecimal literal
-        RETURN_IF_ERROR(_ch, _stream.read());
+        RETURN_IF_ERROR_VOID(read());
         if (!isxdigit(_ch))
         {
             // Reference access
@@ -232,7 +232,7 @@ lex::lexer::get_token()
             number *= base;
             number += _chtou(_ch);
             _head.append(_ch); // In case it's not a literal.
-            RETURN_IF_ERROR(_ch, _stream.read());
+            RETURN_IF_ERROR_VOID(read());
         }
 
         if (text::is_name_continuation(_ch))
@@ -261,6 +261,14 @@ lex::lexer::get_token()
     return std::move(process_string());
 }
 
+result<void>
+lex::lexer::read()
+{
+    RETURN_IF_ERROR(_ch, _stream.read());
+    _column = _isnotcrlf(_ch) ? (_column + 1) : 0;
+    return {};
+}
+
 result<lex::token>
 lex::lexer::process_string()
 {
@@ -274,7 +282,7 @@ lex::lexer::process_string()
     if ('#' == _ch)
     {
         // Directive or subscript
-        RETURN_IF_ERROR(_ch, _stream.read());
+        RETURN_IF_ERROR_VOID(read());
         if (!text::isalpha(_ch) && (',' != _ch))
         {
             // Subscript
@@ -313,7 +321,7 @@ lex::lexer::process_string()
 
         string.append(_ch);
 
-        RETURN_IF_ERROR(_ch, _stream.read());
+        RETURN_IF_ERROR_VOID(read());
     }
 
     if (_is_register(string))
@@ -333,7 +341,7 @@ lex::lexer::scan_while(ustring &out, bool (*predicate)(int))
     {
         out.append(_ch);
 
-        RETURN_IF_ERROR(_ch, _stream.read());
+        RETURN_IF_ERROR_VOID(read());
     }
 
     return {};

--- a/zdc/src/zd/lex/pl_istream.cpp
+++ b/zdc/src/zd/lex/pl_istream.cpp
@@ -131,6 +131,15 @@ lex::pl_istream::read() noexcept
                               _encoding->get_name());
         }
 
+        if ('\n' == codepoint)
+        {
+            _line++;
+            _column = 1;
+        }
+        else
+        {
+            _column++;
+        }
         return codepoint;
     }
 
@@ -153,5 +162,14 @@ lex::pl_istream::read() noexcept
         return make_error(error_code::invalid_sequence);
     }
 
+    if ('\n' == codepoint)
+    {
+        _line++;
+        _column = 1;
+    }
+    else
+    {
+        _column++;
+    }
     return codepoint;
 }

--- a/zdc/src/zd/par/parser.cpp
+++ b/zdc/src/zd/par/parser.cpp
@@ -515,14 +515,14 @@ par::parser::handle_directive(const ustring &directive)
         {
             number *= 10;
             number += *it - '0';
-        }
-        else if (',' == *it)
-        {
+
             if (255 < number)
             {
                 return make_error(error_code::out_of_range, number);
             }
-
+        }
+        else if (',' == *it)
+        {
             bytes.push_back(static_cast<uint8_t>(number));
             number = 0;
         }

--- a/zdc/src/zd/par/parser.cpp
+++ b/zdc/src/zd/par/parser.cpp
@@ -265,7 +265,7 @@ par::parser::handle_call(const ustring &callee, bool enclosed)
         if (!result)
         {
             auto err = std::move(result.error());
-            if (err.is(error_origin::parser, error_code::unexpected_token))
+            if (err.is<parser>(error_code::unexpected_token))
             {
                 auto tts = reinterpret_cast<const char *>(err[0]);
                 if (!enclosed && to_cstr(lex::token_type::lbracket) == tts)
@@ -284,7 +284,7 @@ par::parser::handle_call(const ustring &callee, bool enclosed)
                 }
             }
 
-            if (err.is(error_origin::parser, error_code::name_expected))
+            if (err.is<parser>(error_code::name_expected))
             {
                 auto tts = reinterpret_cast<const char *>(err[1]);
                 if ((to_cstr(lex::token_type::eof) == tts) ||
@@ -754,7 +754,7 @@ par::parser::handle_procedure()
         auto result = handle();
         if (!result)
         {
-            if (result.error().is(error_origin::parser, error_code::eof))
+            if (result.error().is<parser>(error_code::eof))
             {
                 return make_error(error_code::unexpected_eof,
                                   lex::token_type::procedure);

--- a/zdc/src/zd/ustring.cpp
+++ b/zdc/src/zd/ustring.cpp
@@ -147,10 +147,10 @@ ustring::clear()
 }
 
 bool
-zd::operator==(const ustring &left, const ustring &right)
+zd::ustring::operator==(const ustring &that)
 {
-    return (left._size == right._size) &&
-           std::equal(left._data, left._data + left._size, right._data);
+    return (_size == that._size) &&
+           std::equal(_data, _data + _size, that._data);
 }
 
 // zd::ustring::iterator class

--- a/zdc/src/zdc.cpp
+++ b/zdc/src/zdc.cpp
@@ -142,17 +142,21 @@ action_parser(zd::lex::lexer &lexer)
             if (!inc_node->is_binary)
             {
                 // Inclusion directive - #Wstaw
-
-                // Get parent path
-                auto &self = lexer.get_path();
-                auto  dir_end = ++zd::find_last_if(self.begin(), self.end(),
-                                                   is_path_separator);
-
-                // Create included file path
                 zd::ustring inc_path{};
-                std::for_each(self.begin(), dir_end, [&inc_path](int ch) {
-                    inc_path.append(ch);
-                });
+
+                auto &self = lexer.get_path();
+                if (!self.empty())
+                {
+                    // Get parent path
+                    auto dir_end = ++zd::find_last_if(self.begin(), self.end(),
+                                                      is_path_separator);
+
+                    // Create included file path
+                    std::for_each(self.begin(), dir_end, [&inc_path](int ch) {
+                        inc_path.append(ch);
+                    });
+                }
+
                 inc_path.append(inc_node->name);
 
                 // Process the included file

--- a/zdc/src/zdc.cpp
+++ b/zdc/src/zdc.cpp
@@ -122,8 +122,7 @@ action_parser(zd::lex::lexer &lexer)
         if (!result)
         {
             zd::error err = std::move(result.error());
-            if (err.is(zd::error_origin::parser,
-                       zd::par::parser::error_code::eof))
+            if (err.is<zd::par::parser>(zd::par::parser::error_code::eof))
             {
                 // End of file
                 return 0;

--- a/zdc/src/zdc.cpp
+++ b/zdc/src/zdc.cpp
@@ -163,7 +163,13 @@ action_parser(zd::lex::lexer &lexer)
                 zd::lex::pl_istream inc_stream{
                     inc_path, lexer.get_stream().get_encoding()};
                 zd::lex::lexer inc_lexer{inc_stream};
-                action_parser(inc_lexer);
+
+                int status = action_parser(inc_lexer);
+                if (0 != status)
+                {
+                    return status;
+                }
+
                 continue;
             }
         }

--- a/zdc/src/zdc.mc
+++ b/zdc/src/zdc.mc
@@ -1,0 +1,77 @@
+﻿LanguageNames=(English=0x0409:zdc_en_US)
+
+; // Stream errors
+
+MessageId=0x0100
+Language=English
+unexpected byte %1!u! in the encoding '%2!S!'
+.
+
+MessageId=0x0101
+Language=English
+invalid multi-byte sequence
+.
+
+MessageId=0x0102
+Language=English
+read error in a multi-byte sequence
+.
+
+; // Lexer errors
+
+MessageId=0x0200
+Language=English
+invalid line break
+.
+
+MessageId=0x0201
+Language=English
+unexpected character %1!d! in '%2!S!'
+.
+
+; // Parser errors
+
+MessageId=0x0300
+Language=English
+end of file
+.
+
+MessageId=0x0301
+Language=English
+unexpected '%1!S!' in '%2!S!'
+.
+
+MessageId=0x0302
+Language=English
+unexpected end of file while processing '%1!S!'
+.
+
+MessageId=0x0303
+Language=English
+unknown directive
+.
+
+MessageId=0x0304
+Language=English
+number %1!d! is out of range
+.
+
+MessageId=0x0305
+Language=English
+name expected after '%1!S!', got '%2!S!'
+.
+
+MessageId=0x0306
+Language=English
+include path expected
+.
+
+MessageId=0x0307
+Language=English
+unexpected '%1!S!' at the beginning of a command
+.
+
+MessageId=0x0308
+Language=English
+unexpected character %1!u! in the emit directive
+.


### PR DESCRIPTION
Ogólne:
- pozwól na ekstrakcję bufora z klasy `ustring`
- pozwól na przechowywanie w klasie `error` argumentów alokowanych na stercie
- nie stosuj `friend` dla operatorów porównania klasy `ustring`
- dodaj konwerter plików z komunikatami MC na pliki języka C

ZDC:
- przekazuj w błędach nazwę pliku, numer linii i położenie w linii
- wypełnij szczegóły błędu z użyciem szablonów
- wykorzystaj szablony do uszczelnienia sprawdzania pochodzenia błędu
- obsłuż załączanie plików dyrektywą `#Wstaw`
- przerwij działanie przy błędzie w załączonym pliku
- przechowuj komunikaty w pliku MC

Parser:
- rozszerz błędy o położenie w pliku
- popraw sprawdzanie zakresu w dyrektywie `#,`