### PR TITLE
Generuj przykłady z lekcji 2-7

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | LEKCJA03 | ✅ | ✅ | ✅ |
 | LEKCJA04 | ✅ | ✅ | ✅ |
 | LEKCJA05 | ✅ | ✅ | ✅ |
-| LEKCJA06 | ✅ | ✅ |
+| LEKCJA06 | ✅ | ✅ | ✅ |
 | LEKCJA07 | ✅ | ✅ |
 | LEKCJA08 | ✅ | ✅ |
 | LEKCJA09 | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | KURS04 | ✅ | ✅ | ✅ |
 | EFEKT | ✅ | ✅ | ✅ |
 | LEKCJA01 | ✅ | ✅ | ✅ |
-| LEKCJA02 | ✅ | ✅ |
+| LEKCJA02 | ✅ | ✅ | ✅ |
 | LEKCJA03 | ✅ | ✅ |
 | LEKCJA04 | ✅ | ✅ |
 | LEKCJA05 | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | EFEKT | ✅ | ✅ | ✅ |
 | LEKCJA01 | ✅ | ✅ | ✅ |
 | LEKCJA02 | ✅ | ✅ | ✅ |
-| LEKCJA03 | ✅ | ✅ |
-| LEKCJA04 | ✅ | ✅ |
-| LEKCJA05 | ✅ | ✅ |
+| LEKCJA03 | ✅ | ✅ | ✅ |
+| LEKCJA04 | ✅ | ✅ | ✅ |
+| LEKCJA05 | ✅ | ✅ | ✅ |
 | LEKCJA06 | ✅ | ✅ |
 | LEKCJA07 | ✅ | ✅ |
 | LEKCJA08 | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | LEKCJA04 | ✅ | ✅ | ✅ |
 | LEKCJA05 | ✅ | ✅ | ✅ |
 | LEKCJA06 | ✅ | ✅ | ✅ |
-| LEKCJA07 | ✅ | ✅ |
+| LEKCJA07 | ✅ | ✅ | ✅ |
 | LEKCJA08 | ✅ | ✅ |
 | LEKCJA09 | ✅ | ✅ |
 | LEKCJA10 | ✅ | ✅ |
-| LEKCJA11 | ✅ | ✅ |
+| LEKCJA11 | ✅ | ✅ | ✅ |
 | ZADANIA | ✅ | ✅ |
 | **INC** | - | - | - |
 | DOGIER | ✅ | ✅ |

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -95,6 +95,9 @@ class x86_assembler
     jne(const symbol_ref &target);
 
     bool
+    mov(par::cpu_register dst, par::cpu_register src);
+
+    bool
     mov(par::cpu_register dst, const std::vector<char> &src);
 
     bool

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -116,6 +116,9 @@ class x86_assembler
     add(par::cpu_register dst, par::cpu_register src);
 
     bool
+    add(const symbol_ref &dst, unsigned src);
+
+    bool
     inc(par::cpu_register reg);
 
     bool

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -86,6 +86,9 @@ class x86_assembler
     dec(const symbol_ref &dst);
 
     bool
+    jb(const symbol_ref &target);
+
+    bool
     je(const symbol_ref &target);
 
     bool

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -92,7 +92,7 @@ class x86_assembler
     jne(const symbol_ref &target);
 
     bool
-    mov(par::cpu_register dst, const ustring &src);
+    mov(par::cpu_register dst, const std::vector<char> &src);
 
     bool
     mov(par::cpu_register dst, const symbol_ref &src);

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -83,6 +83,9 @@ class x86_assembler
     cmp(mreg left, unsigned right);
 
     bool
+    dec(const symbol_ref &dst);
+
+    bool
     je(const symbol_ref &target);
 
     bool
@@ -132,6 +135,9 @@ class x86_assembler
 
     bool
     ret();
+
+    bool
+    sub(const symbol_ref &dst, unsigned src);
 };
 
 } // namespace gen

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -32,6 +32,9 @@ struct zd4_builtins
     PiszL(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    PiszZnak(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Pozycja(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -14,6 +14,9 @@ class zd4_generator;
 struct zd4_builtins
 {
     static bool
+    Czekaj(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Czysc(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -26,6 +26,9 @@ struct zd4_builtins
     Klawisz(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    Losowa8(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Pisz(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -26,6 +26,9 @@ struct zd4_builtins
     Klawisz(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    Losowa16(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Losowa8(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -58,6 +58,12 @@ struct zd4_builtins
 
     static bool
     Pisz(zd4_generator *generator, const ustring &str);
+
+    static symbol *
+    get_procedure(zd4_generator *generator,
+                  const ustring &name,
+                  const uint8_t *code,
+                  unsigned       size);
 };
 
 } // namespace gen

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -35,6 +35,9 @@ struct zd4_builtins
     PiszZnak(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    Pisz8(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Pozycja(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_section.hpp
+++ b/zdc/include/zd/gen/zd4_section.hpp
@@ -73,13 +73,13 @@ class zd4_section
         return emit(reinterpret_cast<const uint8_t *>(payload), size);
     }
 
-    void
+    unsigned
     emit_byte(uint8_t byte);
 
-    void
+    unsigned
     emit_word(uint16_t word);
 
-    void
+    unsigned
     emit_ref(const zd4_relocation &ref);
 
     unsigned

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -117,6 +117,8 @@ struct assignment_node : public node
     const unique_node target;
     const unique_node source;
 
+    assignment_node() = default;
+
     assignment_node(unique_node target_, unique_node source_)
         : target{std::move(target_)}, source{std::move(source_)}
     {

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -47,6 +47,9 @@
 #define INC_rm16 0xFF // RegOpcode 0
 #define INC_r16  0x40
 
+#define JB_rel8  0x72
+#define JB_rel16 0x820F
+
 #define JE_rel8  0x74
 #define JE_rel16 0x840F
 

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -33,7 +33,8 @@
 #define ModRM_SIDH         0xC6
 #define ModRM_DIBH         0xC7
 
-#define ADD_r16_rm16 0x03
+#define ADD_r16_rm16   0x03
+#define ADD_rm16_imm16 0x81
 
 #define CALL_rel16 0xE8
 

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -34,7 +34,7 @@
 #define ModRM_DIBH         0xC7
 
 #define ADD_r16_rm16   0x03
-#define ADD_rm16_imm16 0x81
+#define ADD_rm16_imm16 0x81 // RegOpcode 0
 
 #define CALL_rel16 0xE8
 
@@ -42,7 +42,9 @@
 #define CMP_AX_imm16   0x3D
 #define CMP_rm16_imm16 0x81
 
-#define INC_rm16 0xFF
+#define DEC_rm16 0xFF // RegOpcode 1
+
+#define INC_rm16 0xFF // RegOpcode 0
 #define INC_r16  0x40
 
 #define JE_rel8  0x74
@@ -62,5 +64,7 @@
 #define MOV_rm16_imm16  0xC7
 
 #define RET_near 0xC3
+
+#define SUB_rm16_imm16 0x81 // RegOpcode 5
 
 #define INT_imm8 0xCD

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -56,6 +56,7 @@
 #define JNE_rel8  0x75
 #define JNE_rel16 0x850F
 
+#define MOV_rm8_r8      0x88
 #define MOV_rm16_r16    0x89
 #define MOV_r8_rm8      0x8A
 #define MOV_r16_rm16    0x8B

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -130,6 +130,15 @@ x86_assembler::cmp(mreg left, unsigned right)
 }
 
 bool
+zd::gen::x86_assembler::dec(const symbol_ref &dst)
+{
+    _code->emit_byte(DEC_rm16);
+    _code->emit_byte(ModRM(ModRM_disp16, 1));
+    _code->emit_ref({dst.sym.address, dst.sym.section, dst.off});
+    return true;
+}
+
+bool
 x86_assembler::cmp(const symbol_ref &left, uint16_t right)
 {
     _code->emit_byte(CMP_rm16_imm16);
@@ -351,5 +360,15 @@ bool
 x86_assembler::ret()
 {
     _code->emit_byte(RET_near);
+    return true;
+}
+
+bool
+zd::gen::x86_assembler::sub(const symbol_ref &dst, unsigned src)
+{
+    _code->emit_byte(SUB_rm16_imm16);
+    _code->emit_byte(ModRM(ModRM_disp16, 5));
+    _code->emit_ref({dst.sym.address, dst.sym.section, dst.off});
+    _code->emit_word(src);
     return true;
 }

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -164,7 +164,7 @@ x86_assembler::jne(const symbol_ref &target)
 }
 
 bool
-x86_assembler::mov(par::cpu_register dst, const ustring &src)
+x86_assembler::mov(par::cpu_register dst, const std::vector<char> &src)
 {
     ASM_REQUIRE(sizeof(uint16_t) == _reg_size(dst));
 

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -207,6 +207,14 @@ x86_assembler::cmp(const symbol_ref &left, uint16_t right)
 }
 
 bool
+x86_assembler::jb(const symbol_ref &target)
+{
+    _code->emit_word(JB_rel16);
+    _code->emit_ref({target.sym.address, target.sym.section, -2, true});
+    return true;
+}
+
+bool
 x86_assembler::je(const symbol_ref &target)
 {
     _code->emit_word(JE_rel16);

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -302,6 +302,16 @@ x86_assembler::add(par::cpu_register dst, par::cpu_register src)
 }
 
 bool
+x86_assembler::add(const symbol_ref &dst, unsigned src)
+{
+    _code->emit_byte(ADD_rm16_imm16);
+    _code->emit_byte(ModRM(ModRM_disp16, 0));
+    _code->emit_ref({dst.sym.address, dst.sym.section, dst.off});
+    _code->emit_word(src);
+    return true;
+}
+
+bool
 x86_assembler::inc(par::cpu_register reg)
 {
     ASM_REQUIRE(sizeof(uint16_t) == _reg_size(reg));

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -205,10 +205,6 @@ bool
 zd4_builtins::Pisz8(zd4_generator *generator, const call_node &node)
 {
     REQUIRE(1 == node.arguments.size());
-    REQUIRE(node.arguments.front()->is<object_node>());
-
-    auto num = node.arguments.front()->as<object_node>();
-    REQUIRE(object_type::word == num->type);
 
     ustring proc_name{"$Pisz8"};
     auto   &procedure = generator->get_symbol(proc_name);
@@ -225,9 +221,23 @@ zd4_builtins::Pisz8(zd4_generator *generator, const call_node &node)
         }
     }
 
-    auto &symbol = generator->get_symbol(num->name);
-    generator->_as.mov(cpu_register::bx, symbol_ref{symbol});
-    generator->_as.mov(cpu_register::cl, mreg{cpu_register::bx});
+    if (node.arguments.front()->is<register_node>())
+    {
+        auto reg = node.arguments.front()->as<register_node>();
+        generator->_as.mov(cpu_register::cl, reg->reg);
+    }
+    else
+    {
+        REQUIRE(node.arguments.front()->is<object_node>());
+
+        auto num = node.arguments.front()->as<object_node>();
+        REQUIRE(object_type::word == num->type);
+
+        auto &symbol = generator->get_symbol(num->name);
+        generator->_as.mov(cpu_register::bx, symbol_ref{symbol});
+        generator->_as.mov(cpu_register::cl, mreg{cpu_register::bx});
+    }
+
     generator->_as.call(procedure);
 
     return true;

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -12,6 +12,21 @@ using namespace zd::par;
     }
 
 bool
+zd4_builtins::Czekaj(zd4_generator *generator, const par::call_node &node)
+{
+    REQUIRE(1 == node.arguments.size());
+    REQUIRE(node.arguments.front()->is<number_node>());
+
+    // INT 15,86 - Elapsed Time Wait (AT and PS/2)
+    generator->_as.mov(cpu_register::ax, 0x8600);
+    generator->_as.mov(cpu_register::cx,
+                       node.arguments.front()->as<number_node>()->value);
+    generator->_as.mov(cpu_register::dx, 0);
+    generator->_as.intr(0x15);
+    return true;
+}
+
+bool
 zd4_builtins::Czysc(zd4_generator *generator, const par::call_node &node)
 {
     uint8_t attribute{0x07};

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -91,7 +91,7 @@ zd4_builtins::Klawisz(zd4_generator *generator, const par::call_node &node)
 bool
 zd4_builtins::Pisz(zd4_generator *generator)
 {
-    ustring data{"\r\n$"};
+    std::vector<char> data{'\r', '\n', '$'};
 
     // INT 21,9 - Print String
     generator->_as.mov(cpu_register::dx, data);
@@ -103,9 +103,16 @@ zd4_builtins::Pisz(zd4_generator *generator)
 bool
 zd4_builtins::Pisz(zd4_generator *generator, const ustring &str)
 {
-    ustring data{str};
-    data.append('$');
-    // TODO: Convert to CP852
+    std::vector<char> data{};
+    data.resize(str.size() + 1);
+
+    auto ptr = data.data();
+    for (auto cp : str)
+    {
+        text::encoding::ibm852->encode(ptr, cp);
+        ptr++;
+    }
+    *ptr = '$';
 
     // INT 21,9 - Print String
     generator->_as.mov(cpu_register::dx, data);

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -88,6 +88,42 @@ zd4_builtins::Klawisz(zd4_generator *generator, const par::call_node &node)
     return true;
 }
 
+// Procedure $Losowa8
+static const uint8_t Losowa8_impl[]{
+    0x1E,             // push ds
+    0x33, 0xC0,       // xor ax, ax
+    0x8E, 0xD8,       // mov ds, ax
+    0xA0, 0x6C, 0x04, // mov al, [046Ch]
+    0x34, 0xAA,       // xor al, AAh
+    0x1F,             // pop ds
+    0xC3,             // ret
+};
+
+bool
+zd4_builtins::Losowa8(zd4_generator *generator, const call_node &node)
+{
+    REQUIRE(node.arguments.empty());
+
+    ustring proc_name{"$Losowa8"};
+    auto   &procedure = generator->get_symbol(proc_name);
+    if (symbol_type::undefined == procedure.type)
+    {
+        zd4_generator::nesting_guard nested{*generator};
+
+        if (!generator->set_symbol(
+                proc_name, symbol_type::procedure,
+                static_cast<zd4_known_section>(generator->_curr_code->index),
+                generator->_curr_code->emit(Losowa8_impl, sizeof(Losowa8_impl))))
+        {
+            return false;
+        }
+    }
+
+    generator->_as.call(procedure);
+
+    return true;
+}
+
 bool
 zd4_builtins::Pisz(zd4_generator *generator)
 {

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -162,6 +162,11 @@ zd4_builtins::Pisz(zd4_generator *generator, const call_node &node)
 bool
 zd4_builtins::PiszL(zd4_generator *generator, const call_node &node)
 {
+    if (node.is_bare)
+    {
+        return Pisz(generator);
+    }
+
     if (node.arguments.size() && node.arguments.front()->is<string_node>())
     {
         ustring value{node.arguments.front()->as<string_node>()->value};

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -88,6 +88,31 @@ zd4_builtins::Klawisz(zd4_generator *generator, const par::call_node &node)
     return true;
 }
 
+// Procedure $Losowa16
+static const uint8_t Losowa16_impl[]{
+    0x1E,             // push ds
+    0x33, 0xC0,       // xor ax, ax
+    0x8E, 0xD8,       // mov ds, ax
+    0xA1, 0x6C, 0x04, // mov ax, [046Ch]
+    0x35, 0xAA, 0xAA, // xor ax, AAAAh
+    0x1F,             // pop ds
+    0xC3,             // ret
+};
+
+bool
+zd4_builtins::Losowa16(zd4_generator *generator, const call_node &node)
+{
+    REQUIRE(node.arguments.empty());
+
+    auto procedure = get_procedure(generator, "$Losowa16", Losowa16_impl,
+                                   sizeof(Losowa16_impl));
+    REQUIRE(procedure);
+
+    generator->_as.call(*procedure);
+
+    return true;
+}
+
 // Procedure $Losowa8
 static const uint8_t Losowa8_impl[]{
     0x1E,             // push ds

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -174,6 +174,44 @@ zd4_builtins::PiszL(zd4_generator *generator, const call_node &node)
 }
 
 bool
+zd4_builtins::PiszZnak(zd4_generator *generator, const call_node &node)
+{
+    REQUIRE(!node.arguments.empty());
+    REQUIRE(3 >= node.arguments.size());
+
+    // Character code
+    auto it = node.arguments.begin();
+    REQUIRE((*it)->is<number_node>());
+    uint8_t character = (*it)->as<number_node>()->value;
+
+    // Display attribute (colors)
+    uint8_t attribute{7};
+    if (1 < node.arguments.size())
+    {
+        it++;
+        REQUIRE((*it)->is<number_node>());
+        attribute = (*it)->as<number_node>()->value;
+    }
+
+    // Number of repetitions
+    uint16_t count{1};
+    if (1 < node.arguments.size())
+    {
+        it++;
+        REQUIRE((*it)->is<number_node>());
+        count = (*it)->as<number_node>()->value;
+    }
+
+    // INT 10,9 - Write Character and Attribute at Cursor Position
+    generator->_as.mov(cpu_register::ax, 0x0900 | character);
+    generator->_as.mov(cpu_register::bx, attribute);
+    generator->_as.mov(cpu_register::cx, count);
+    generator->_as.intr(0x10);
+
+    return true;
+}
+
+bool
 zd4_builtins::Pozycja(zd4_generator *generator, const par::call_node &node)
 {
     REQUIRE(2 == node.arguments.size());

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -309,7 +309,8 @@ zd4_generator::process(const par::operation_node &node)
                 return true;
             }
 
-            return false;
+            _as.add(symbol_ref{left_sym}, right_num->value);
+            return true;
         }
 
         return false;

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -91,6 +91,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::PiszZnak(this, node);
     }
 
+    if (text::pl_streqi("Pisz8", node.callee))
+    {
+        return zd4_builtins::Pisz8(this, node);
+    }
+
     if (text::pl_streqi("Pozycja", node.callee))
     {
         return zd4_builtins::Pozycja(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -124,6 +124,10 @@ zd4_generator::process(const par::condition_node &node)
         return _as.je(symbol);
     }
 
+    case condition::less_than: {
+        return _as.jb(symbol);
+    }
+
     case condition::nonequal: {
         return _as.jne(symbol);
     }

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -86,6 +86,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::PiszL(this, node);
     }
 
+    if (text::pl_streqi("PiszZnak", node.callee))
+    {
+        return zd4_builtins::PiszZnak(this, node);
+    }
+
     if (text::pl_streqi("Pozycja", node.callee))
     {
         return zd4_builtins::Pozycja(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -59,6 +59,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Klawisz(this, node);
     }
 
+    if (text::pl_streqi("Losowa16", node.callee))
+    {
+        return zd4_builtins::Losowa16(this, node);
+    }
+
     if (text::pl_streqi("Losowa8", node.callee))
     {
         return zd4_builtins::Losowa8(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -20,23 +20,6 @@ using namespace zd::par;
         out = (node_ptr)->as<std::remove_pointer<decltype(out)>::type>();      \
     }
 
-uint8_t
-mreg::encode() const
-{
-    switch (reg)
-    {
-    case cpu_register::si:
-        return ModRM_SI;
-
-    case cpu_register::di:
-        return ModRM_DI;
-
-    case cpu_register::bx:
-        return ModRM_BX;
-    }
-    return 0xFF;
-}
-
 bool
 zd4_generator::process(const par::assignment_node &node)
 {

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -56,6 +56,11 @@ zd4_generator::process(const par::assignment_node &node)
 bool
 zd4_generator::process(const par::call_node &node)
 {
+    if (text::pl_streqi("Czekaj", node.callee))
+    {
+        return zd4_builtins::Czekaj(this, node);
+    }
+
     if (text::pl_streqai("Czyść", node.callee))
     {
         return zd4_builtins::Czysc(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -338,6 +338,30 @@ zd4_generator::process(const par::operation_node &node)
 
         return false;
     }
+
+    case operation::subtract: {
+        if (node.left->is<object_node>() && node.right->is<number_node>())
+        {
+            auto left_obj = node.left->as<object_node>();
+            if (object_type::word != left_obj->type)
+            {
+                return false;
+            }
+
+            auto &left_sym = get_symbol(left_obj->name);
+            auto  right_num = node.right->as<number_node>();
+            if (1 == right_num->value)
+            {
+                _as.dec(symbol_ref{left_sym});
+                return true;
+            }
+
+            _as.sub(symbol_ref{left_sym}, right_num->value);
+            return true;
+        }
+
+        return false;
+    }
     }
 
     return false;

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -59,6 +59,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Klawisz(this, node);
     }
 
+    if (text::pl_streqi("Losowa8", node.callee))
+    {
+        return zd4_builtins::Losowa8(this, node);
+    }
+
     if (text::pl_streqi("Pisz", node.callee))
     {
         return zd4_builtins::Pisz(this, node);

--- a/zdc/src/zd/gen/zd4_section.cpp
+++ b/zdc/src/zd/gen/zd4_section.cpp
@@ -62,25 +62,25 @@ zd4_section::emit(const uint8_t *payload, unsigned size)
     return std::exchange(_offset, _offset + size);
 }
 
-void
+unsigned
 zd4_section::emit_byte(uint8_t byte)
 {
     std::fwrite(&byte, sizeof(byte), 1, _pf);
-    _offset += sizeof(byte);
+    return std::exchange(_offset, _offset + (unsigned)sizeof(byte));
 }
 
-void
+unsigned
 zd4_section::emit_word(uint16_t word)
 {
     std::fwrite(&word, sizeof(word), 1, _pf);
-    _offset += sizeof(word);
+    return std::exchange(_offset, _offset + (unsigned)sizeof(word));
 }
 
-void
+unsigned
 zd4_section::emit_ref(const zd4_relocation &ref)
 {
     _relocs.push_back({_offset, ref.section, ref.offset, ref.relative});
-    emit_word(ref.address);
+    return emit_word(ref.address);
 }
 
 unsigned


### PR DESCRIPTION
ZD4:
- obsłuż `Czekaj` i konwertuj literały tekstowe na CP852 (zgodność: LEKCJA02)
- obsłuż `PiszZnak` (zgodność: LEKCJA03, LEKCJA04, LEKCJA05)
- obsłuż stałe, `Pisz8`, bezargumentowe `PiszL`, oraz `Zmniejsz` i `Zwiększ` z liczbą (zgodność: LEKCJA06)
- obsłuż `Pisz8` z rejestrem, `Losowa8` i `Losowa16` (zgodność: LEKCJA07)
- dodaj jednolity mechanizm generowania procedur wbudowanych