### PR TITLE
Generuj przykłady z lekcji 8-10

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | LEKCJA05 | ✅ | ✅ | ✅ |
 | LEKCJA06 | ✅ | ✅ | ✅ |
 | LEKCJA07 | ✅ | ✅ | ✅ |
-| LEKCJA08 | ✅ | ✅ |
+| LEKCJA08 | ✅ | ✅ | ✅ |
 | LEKCJA09 | ✅ | ✅ |
 | LEKCJA10 | ✅ | ✅ |
 | LEKCJA11 | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | ZADANIA | ✅ | ✅ | ✅ |
 | **INC** | - | - | - |
 | DOGIER | ✅ | ✅ |
-| DZWIEK | ✅ | ✅ |
+| DZWIEK | ✅ | ✅ | ✅ |
 | DZWIEK2 | ✅ | ✅ |
 | KLAWIAT | ✅ | ✅ |
 | MYSZ | ✅ | ✅ |
@@ -38,24 +38,24 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | **PRZYKLAD** | - | - | - |
 | DOWCIPY | ✅ | ✅ |
 | GRA | ✅ | ✅ |
-| KWADRAT | ✅ | ✅ |
+| KWADRAT | ✅ | ✅ | ✅ |
 | LINIA | ✅ | ✅ |
-| PETLE | ✅ | ✅ |
+| PETLE | ✅ | ✅ | ✅ |
 | ZC | ✅ | ✅ |
-| !TLO | ✅ | ✅ |
-| ALARM | ✅ | ✅ |
+| !TLO | ✅ | ✅ | ✅ |
+| ALARM | ✅ | ✅ | ✅ |
 | ASCII | ✅ | ✅ |
-| COOL-GR1 | ✅ | ✅ |
+| COOL-GR1 | ✅ | ✅ | ✅ |
 | DEMO | ✅ | ✅ |
-| DZWIEK | ✅ | ✅ |
-| EFEKT | ✅ | ✅ |
+| DZWIEK | ✅ | ✅ | ✅ |
+| EFEKT | ✅ | ✅ | ✅ |
 | LOSOWE | ✅ | ✅ |
-| MYSZ | ✅ | ✅ |
-| MYSZKA | ✅ | ✅ |
+| MYSZ | ✅ | ✅ | ✅ |
+| MYSZKA | ✅ | ✅ | ✅ |
 | MYSZRYS | ✅ | ✅ |
 | PARAMETR | ✅ | ✅ |
 | PLIKI1 | ✅ | ✅ |
 | PLIKI2 | ✅ | ✅ |
-| SKOKI | ✅ | ✅ |
-| TESTMYSZ | ✅ | ✅ |
-| WSTAW | ✅ | ✅ |
+| SKOKI | ✅ | ✅ | ✅ |
+| TESTMYSZ | ✅ | ✅ | ✅ |
+| WSTAW | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | LEKCJA06 | ✅ | ✅ | ✅ |
 | LEKCJA07 | ✅ | ✅ | ✅ |
 | LEKCJA08 | ✅ | ✅ | ✅ |
-| LEKCJA09 | ✅ | ✅ |
+| LEKCJA09 | ✅ | ✅ | ✅ |
 | LEKCJA10 | ✅ | ✅ |
 | LEKCJA11 | ✅ | ✅ | ✅ |
-| ZADANIA | ✅ | ✅ |
+| ZADANIA | ✅ | ✅ | ✅ |
 | **INC** | - | - | - |
 | DOGIER | ✅ | ✅ |
 | DZWIEK | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | LEKCJA07 | ✅ | ✅ | ✅ |
 | LEKCJA08 | ✅ | ✅ | ✅ |
 | LEKCJA09 | ✅ | ✅ | ✅ |
-| LEKCJA10 | ✅ | ✅ |
+| LEKCJA10 | ✅ | ✅ | ✅ |
 | LEKCJA11 | ✅ | ✅ | ✅ |
 | ZADANIA | ✅ | ✅ | ✅ |
 | **INC** | - | - | - |
@@ -52,7 +52,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | LOSOWE | ✅ | ✅ |
 | MYSZ | ✅ | ✅ | ✅ |
 | MYSZKA | ✅ | ✅ | ✅ |
-| MYSZRYS | ✅ | ✅ |
+| MYSZRYS | ✅ | ✅ | ✅ |
 | PARAMETR | ✅ | ✅ |
 | PLIKI1 | ✅ | ✅ |
 | PLIKI2 | ✅ | ✅ |

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -149,6 +149,9 @@ class x86_assembler
     ret();
 
     bool
+    shr(par::cpu_register reg, par::cpu_register cl);
+
+    bool
     sub(const symbol_ref &dst, unsigned src);
 };
 

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -14,6 +14,7 @@ enum class symbol_type
     undefined,
     label,
     procedure,
+    var_byte,
     var_text,
     var_word,
 };

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -122,6 +122,9 @@ class x86_assembler
     mov(par::cpu_register dst, unsigned src);
 
     bool
+    outb();
+
+    bool
     add(par::cpu_register dst, par::cpu_register src);
 
     bool

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -86,6 +86,9 @@ class x86_assembler
     dec(const symbol_ref &dst);
 
     bool
+    inb();
+
+    bool
     jb(const symbol_ref &target);
 
     bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -59,6 +59,9 @@ struct zd4_builtins
     TworzPlik(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    UsunKatalog(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     UsunPlik(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -32,6 +32,9 @@ struct zd4_builtins
     Losowa8(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    Otworz(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Pisz(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -68,6 +68,9 @@ struct zd4_builtins
     UsunPlik(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    Zamknij(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     ZmienKatalog(zd4_generator *generator, const par::call_node &node);
 
   private:

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -52,6 +52,9 @@ struct zd4_builtins
     static bool
     Tryb(zd4_generator *generator, const par::call_node &node);
 
+    static bool
+    TworzKatalog(zd4_generator *generator, const par::call_node &node);
+
   private:
     static bool
     Pisz(zd4_generator *generator);

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -50,6 +50,9 @@ struct zd4_builtins
     Pozycja(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    Przerwanie(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Punkt(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -55,6 +55,9 @@ struct zd4_builtins
     static bool
     TworzKatalog(zd4_generator *generator, const par::call_node &node);
 
+    static bool
+    ZmienKatalog(zd4_generator *generator, const par::call_node &node);
+
   private:
     static bool
     Pisz(zd4_generator *generator);

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -53,6 +53,9 @@ struct zd4_builtins
     Pozycja(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    PokazMysz(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Przerwanie(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -79,6 +79,9 @@ struct zd4_builtins
     static bool
     ZmienKatalog(zd4_generator *generator, const par::call_node &node);
 
+    static bool
+    ZPortu(zd4_generator *generator, const par::call_node &node);
+
   private:
     static bool
     Pisz(zd4_generator *generator);

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -80,6 +80,9 @@ struct zd4_builtins
     static bool
     Pisz(zd4_generator *generator, const ustring &str);
 
+    static bool
+    Pisz(zd4_generator *generator, unsigned fileno, const ustring &str);
+
     static symbol *
     get_procedure(zd4_generator *generator,
                   const ustring &name,

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -76,6 +76,9 @@ struct zd4_builtins
                   const ustring &name,
                   const uint8_t *code,
                   unsigned       size);
+
+    static bool
+    file_operation(zd4_generator *generator, par::node &arg);
 };
 
 } // namespace gen

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -71,6 +71,9 @@ struct zd4_builtins
     TworzPlik(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    UkryjMysz(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     UsunKatalog(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -23,6 +23,9 @@ struct zd4_builtins
     Czytaj(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    DoPortu(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Klawisz(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -56,6 +56,9 @@ struct zd4_builtins
     TworzKatalog(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    TworzPlik(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     ZmienKatalog(zd4_generator *generator, const par::call_node &node);
 
   private:

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -62,6 +62,9 @@ struct zd4_builtins
     Punkt(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    StanPrzyciskow(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Tryb(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -94,6 +94,11 @@ struct zd4_builtins
 
     static bool
     file_operation(zd4_generator *generator, par::node &arg);
+
+    static bool
+    load_numeric_argument(zd4_generator    *generator,
+                          par::cpu_register reg,
+                          par::node        &arg);
 };
 
 } // namespace gen

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -59,6 +59,9 @@ struct zd4_builtins
     TworzPlik(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    UsunPlik(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     ZmienKatalog(zd4_generator *generator, const par::call_node &node);
 
   private:

--- a/zdc/include/zd/gen/zd4_generator.hpp
+++ b/zdc/include/zd/gen/zd4_generator.hpp
@@ -54,10 +54,7 @@ class zd4_generator : public generator, public zd4_reference_resolver
     process(const par::end_node &node) override;
 
     bool
-    process(const par::emit_node &node) override
-    {
-        return false;
-    }
+    process(const par::emit_node &node) override;
 
     bool
     process(const par::include_node &node) override

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -325,6 +325,8 @@ struct subscript_node : public node
 {
     const unique_node value;
 
+    subscript_node() = default;
+
     subscript_node(unique_node value_) : value{std::move(value_)}
     {
     }

--- a/zdc/include/zd/ustring.hpp
+++ b/zdc/include/zd/ustring.hpp
@@ -8,6 +8,13 @@
 namespace zd
 {
 
+namespace text
+{
+
+struct encoding;
+
+}
+
 class ustring
 {
   public:
@@ -132,6 +139,9 @@ class ustring
         _capacity = 0;
         return std::exchange(_data, nullptr);
     }
+
+    char *
+    encode(char *dst, text::encoding *enc) const;
 
     bool
     reserve(size_t new_cap);

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -67,6 +67,8 @@
 #define MOV_reg16_imm16 0xB8
 #define MOV_rm16_imm16  0xC7
 
+#define OUT_DX_AL 0xEE
+
 #define RET_near 0xC3
 
 #define SUB_rm16_imm16 0x81 // RegOpcode 5

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -44,6 +44,8 @@
 
 #define DEC_rm16 0xFF // RegOpcode 1
 
+#define IN_AL_DX 0xEC
+
 #define INC_rm16 0xFF // RegOpcode 0
 #define INC_r16  0x40
 

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -68,6 +68,7 @@
 #define MOV_r16_rm16    0x8B
 #define MOV_reg8_imm8   0xB0
 #define MOV_reg16_imm16 0xB8
+#define MOV_rm8_imm8    0xC6
 #define MOV_rm16_imm16  0xC7
 
 #define OUT_DX_AL 0xEE

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -74,6 +74,8 @@
 
 #define RET_near 0xC3
 
+#define SHR_rm16_CL 0xD3 // RegOpcode 5
+
 #define SUB_rm16_imm16 0x81 // RegOpcode 5
 
 #define INT_imm8 0xCD

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -47,6 +47,7 @@
 
 #define IN_AL_DX 0xEC
 
+#define INC_rm8  0xFE // RegOpcode 0
 #define INC_rm16 0xFF // RegOpcode 0
 #define INC_r16  0x40
 

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -39,8 +39,9 @@
 #define CALL_rel16 0xE8
 
 #define CMP_AL_imm8    0x3C
+#define CMP_rm8_imm8   0x80 // RegOpcode 7
 #define CMP_AX_imm16   0x3D
-#define CMP_rm16_imm16 0x81
+#define CMP_rm16_imm16 0x81 // RegOpcode 7
 
 #define DEC_rm16 0xFF // RegOpcode 1
 

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -341,6 +341,13 @@ x86_assembler::mov(par::cpu_register dst, unsigned src)
 }
 
 bool
+zd::gen::x86_assembler::outb()
+{
+    _code->emit_byte(OUT_DX_AL);
+    return true;
+}
+
+bool
 x86_assembler::add(par::cpu_register dst, par::cpu_register src)
 {
     ASM_REQUIRE(_reg_size(dst) == _reg_size(src));

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -409,7 +409,8 @@ x86_assembler::inc(mreg reg)
 bool
 x86_assembler::inc(const symbol_ref &dst)
 {
-    _code->emit_byte(INC_rm16);
+    _code->emit_byte((symbol_type::var_byte == dst.sym.type) ? INC_rm8
+                                                             : INC_rm16);
     _code->emit_byte(ModRM(ModRM_disp16, 0));
     _code->emit_ref({dst.sym.address, dst.sym.section, dst.off});
     return true;

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -194,7 +194,7 @@ x86_assembler::cmp(mreg left, unsigned right)
 }
 
 bool
-zd::gen::x86_assembler::dec(const symbol_ref &dst)
+x86_assembler::dec(const symbol_ref &dst)
 {
     _code->emit_byte(DEC_rm16);
     _code->emit_byte(ModRM(ModRM_disp16, 1));
@@ -203,7 +203,7 @@ zd::gen::x86_assembler::dec(const symbol_ref &dst)
 }
 
 bool
-zd::gen::x86_assembler::inb()
+x86_assembler::inb()
 {
     _code->emit_byte(IN_AL_DX);
     return true;
@@ -252,7 +252,7 @@ x86_assembler::jne(const symbol_ref &target)
 }
 
 bool
-zd::gen::x86_assembler::mov(par::cpu_register dst, par::cpu_register src)
+x86_assembler::mov(par::cpu_register dst, par::cpu_register src)
 {
     ASM_REQUIRE(_reg_size(src) == _reg_size(dst));
 
@@ -354,7 +354,7 @@ x86_assembler::mov(par::cpu_register dst, unsigned src)
 }
 
 bool
-zd::gen::x86_assembler::outb()
+x86_assembler::outb()
 {
     _code->emit_byte(OUT_DX_AL);
     return true;
@@ -425,7 +425,17 @@ x86_assembler::ret()
 }
 
 bool
-zd::gen::x86_assembler::sub(const symbol_ref &dst, unsigned src)
+x86_assembler::shr(par::cpu_register reg, par::cpu_register cl)
+{
+    ASM_REQUIRE(cpu_register::cl == cl);
+
+    _code->emit_byte(SHR_rm16_CL);
+    _code->emit_byte(ModRM(_to_mode(reg), 5));
+    return true;
+}
+
+bool
+x86_assembler::sub(const symbol_ref &dst, unsigned src)
 {
     _code->emit_byte(SUB_rm16_imm16);
     _code->emit_byte(ModRM(ModRM_disp16, 5));

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -314,10 +314,18 @@ x86_assembler::mov(par::cpu_register dst, mreg src)
 bool
 x86_assembler::mov(const symbol_ref &dst, uint16_t src)
 {
-    _code->emit_byte(MOV_rm16_imm16);
+    _code->emit_byte((symbol_type::var_byte == dst.sym.type) ? MOV_rm8_imm8
+                                                             : MOV_rm16_imm16);
     _code->emit_byte(ModRM(ModRM_disp16, 0));
     _code->emit_ref({dst.sym.address, dst.sym.section, dst.off});
-    _code->emit_word(src);
+    if (symbol_type::var_byte == dst.sym.type)
+    {
+        _code->emit_byte(src);
+    }
+    else
+    {
+        _code->emit_word(src);
+    }
     return true;
 }
 

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -197,6 +197,13 @@ zd::gen::x86_assembler::dec(const symbol_ref &dst)
 }
 
 bool
+zd::gen::x86_assembler::inb()
+{
+    _code->emit_byte(IN_AL_DX);
+    return true;
+}
+
+bool
 x86_assembler::cmp(const symbol_ref &left, uint16_t right)
 {
     _code->emit_byte(CMP_rm16_imm16);

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -151,7 +151,10 @@ x86_assembler::cmp(par::cpu_register left, unsigned right)
             return true;
         }
 
-        return false;
+        _code->emit_byte(CMP_rm8_imm8);
+        _code->emit_byte(ModRM(_to_mode(left), 7));
+        _code->emit_byte(right);
+        return true;
     }
 
     if (sizeof(uint16_t) == _reg_size(left))
@@ -165,7 +168,10 @@ x86_assembler::cmp(par::cpu_register left, unsigned right)
             return true;
         }
 
-        return false;
+        _code->emit_byte(CMP_rm16_imm16);
+        _code->emit_byte(ModRM(_to_mode(left), 7));
+        _code->emit_word(right);
+        return true;
     }
 
     return false;

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -680,13 +680,30 @@ zd4_builtins::load_numeric_argument(zd4_generator    *generator,
     if (arg.is<object_node>())
     {
         auto obj = arg.as<object_node>();
-        REQUIRE(object_type::word == obj->type);
-
         auto &symbol = generator->get_symbol(obj->name);
         generator->_as.mov(cpu_register::si, symbol_ref{symbol});
         generator->_as.mov(reg, mreg{cpu_register::si});
 
         return true;
+    }
+
+    if (arg.is<register_node>())
+    {
+        auto src_reg = arg.as<register_node>();
+
+        if ((unsigned)reg & 0xFF)
+        {
+            // The same register or parts
+            if (reg == src_reg->reg)
+            {
+                // The same exact register
+                return true;
+            }
+
+            return false;
+        }
+
+        return generator->_as.mov(reg, src_reg->reg);
     }
 
     return false;

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -289,9 +289,26 @@ zd4_builtins::PiszL(zd4_generator *generator, const call_node &node)
         return Pisz(generator);
     }
 
-    if (node.arguments.size() && node.arguments.front()->is<string_node>())
+    REQUIRE(node.arguments.size());
+
+    auto it = node.arguments.begin();
+    if ((*it)->is<subscript_node>())
     {
-        ustring value{node.arguments.front()->as<string_node>()->value};
+        auto subscript = (*it)->as<subscript_node>();
+        REQUIRE(subscript->value->is<number_node>());
+        auto fileno = subscript->value->as<number_node>()->value;
+
+        it++;
+        REQUIRE((*it)->is<string_node>());
+        ustring value{(*it)->as<string_node>()->value};
+        value.append('\r');
+        value.append('\n');
+        return Pisz(generator, fileno, value);
+    }
+
+    if ((*it)->is<string_node>())
+    {
+        ustring value{(*it)->as<string_node>()->value};
         value.append('\r');
         value.append('\n');
         return Pisz(generator, value);

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -437,6 +437,29 @@ zd4_builtins::TworzKatalog(zd4_generator *generator, const par::call_node &node)
 }
 
 bool
+zd4_builtins::TworzPlik(zd4_generator *generator, const par::call_node &node)
+{
+    REQUIRE(1 == node.arguments.size());
+    REQUIRE(node.arguments.front()->is<string_node>());
+
+    auto &name = node.arguments.front()->as<string_node>()->value;
+
+    std::vector<char> data{};
+    data.resize(name.size() + 1);
+
+    auto ptr = name.encode(data.data(), text::encoding::ibm852);
+    *ptr = 0;
+
+    // INT 21,3C - Create File Using Handle
+    generator->_as.mov(cpu_register::ah, 0x3C);
+    generator->_as.mov(cpu_register::cx, 0);
+    generator->_as.mov(cpu_register::dx, data);
+    generator->_as.intr(0x21);
+
+    return true;
+}
+
+bool
 zd::gen::zd4_builtins::ZmienKatalog(zd4_generator        *generator,
                                     const par::call_node &node)
 {

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -156,12 +156,7 @@ zd4_builtins::Pisz(zd4_generator *generator, const ustring &str)
     std::vector<char> data{};
     data.resize(str.size() + 1);
 
-    auto ptr = data.data();
-    for (auto cp : str)
-    {
-        text::encoding::ibm852->encode(ptr, cp);
-        ptr++;
-    }
+    auto ptr = str.encode(data.data(), text::encoding::ibm852);
     *ptr = '$';
 
     // INT 21,9 - Print String
@@ -430,12 +425,7 @@ zd4_builtins::TworzKatalog(zd4_generator *generator, const par::call_node &node)
     std::vector<char> data{};
     data.resize(name.size() + 1);
 
-    auto ptr = data.data();
-    for (auto cp : name)
-    {
-        text::encoding::ibm852->encode(ptr, cp);
-        ptr++;
-    }
+    auto ptr = name.encode(data.data(), text::encoding::ibm852);
     *ptr = 0;
 
     // INT 21,39 - Create Subdirectory (mkdir)

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -442,6 +442,16 @@ zd4_builtins::Pozycja(zd4_generator *generator, const par::call_node &node)
 }
 
 bool
+zd::gen::zd4_builtins::PokazMysz(zd4_generator        *generator,
+                                 const par::call_node &node)
+{
+    // INT 33,1 - Show Mouse Cursor
+    generator->_as.mov(cpu_register::ax, 1);
+    generator->_as.intr(0x33);
+    return true;
+}
+
+bool
 zd::gen::zd4_builtins::Przerwanie(zd4_generator        *generator,
                                   const par::call_node &node)
 {

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -418,45 +418,21 @@ bool
 zd4_builtins::TworzKatalog(zd4_generator *generator, const par::call_node &node)
 {
     REQUIRE(1 == node.arguments.size());
-    REQUIRE(node.arguments.front()->is<string_node>());
-
-    auto &name = node.arguments.front()->as<string_node>()->value;
-
-    std::vector<char> data{};
-    data.resize(name.size() + 1);
-
-    auto ptr = name.encode(data.data(), text::encoding::ibm852);
-    *ptr = 0;
 
     // INT 21,39 - Create Subdirectory (mkdir)
     generator->_as.mov(cpu_register::ah, 0x39);
-    generator->_as.mov(cpu_register::dx, data);
-    generator->_as.intr(0x21);
-
-    return true;
+    return file_operation(generator, *node.arguments.front());
 }
 
 bool
 zd4_builtins::TworzPlik(zd4_generator *generator, const par::call_node &node)
 {
     REQUIRE(1 == node.arguments.size());
-    REQUIRE(node.arguments.front()->is<string_node>());
-
-    auto &name = node.arguments.front()->as<string_node>()->value;
-
-    std::vector<char> data{};
-    data.resize(name.size() + 1);
-
-    auto ptr = name.encode(data.data(), text::encoding::ibm852);
-    *ptr = 0;
 
     // INT 21,3C - Create File Using Handle
     generator->_as.mov(cpu_register::ah, 0x3C);
     generator->_as.mov(cpu_register::cx, 0);
-    generator->_as.mov(cpu_register::dx, data);
-    generator->_as.intr(0x21);
-
-    return true;
+    return file_operation(generator, *node.arguments.front());
 }
 
 bool
@@ -464,22 +440,10 @@ zd::gen::zd4_builtins::ZmienKatalog(zd4_generator        *generator,
                                     const par::call_node &node)
 {
     REQUIRE(1 == node.arguments.size());
-    REQUIRE(node.arguments.front()->is<string_node>());
-
-    auto &name = node.arguments.front()->as<string_node>()->value;
-
-    std::vector<char> data{};
-    data.resize(name.size() + 1);
-
-    auto ptr = name.encode(data.data(), text::encoding::ibm852);
-    *ptr = 0;
 
     // INT 21,3B - Change Current Directory (chdir)
     generator->_as.mov(cpu_register::ah, 0x3B);
-    generator->_as.mov(cpu_register::dx, data);
-    generator->_as.intr(0x21);
-
-    return true;
+    return file_operation(generator, *node.arguments.front());
 }
 
 symbol *
@@ -503,4 +467,23 @@ zd4_builtins::get_procedure(zd4_generator *generator,
     }
 
     return &procedure;
+}
+
+bool
+zd::gen::zd4_builtins::file_operation(zd4_generator *generator, par::node &arg)
+{
+    REQUIRE(arg.is<string_node>());
+
+    auto &name = arg.as<string_node>()->value;
+
+    std::vector<char> data{};
+    data.resize(name.size() + 1);
+
+    auto ptr = name.encode(data.data(), text::encoding::ibm852);
+    *ptr = 0;
+
+    generator->_as.mov(cpu_register::dx, data);
+    generator->_as.intr(0x21);
+
+    return true;
 }

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -489,6 +489,16 @@ zd4_builtins::Punkt(zd4_generator *generator, const par::call_node &node)
 }
 
 bool
+zd::gen::zd4_builtins::StanPrzyciskow(zd4_generator        *generator,
+                                      const par::call_node &node)
+{
+    // INT 33,3 - Get Mouse Position and Button Status
+    generator->_as.mov(cpu_register::ax, 3);
+    generator->_as.intr(0x33);
+    return true;
+}
+
+bool
 zd4_builtins::Tryb(zd4_generator *generator, const par::call_node &node)
 {
     REQUIRE(1 == node.arguments.size());

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -565,6 +565,16 @@ zd::gen::zd4_builtins::ZmienKatalog(zd4_generator        *generator,
     return file_operation(generator, *node.arguments.front());
 }
 
+bool
+zd::gen::zd4_builtins::ZPortu(zd4_generator        *generator,
+                              const par::call_node &node)
+{
+    REQUIRE(node.is_bare);
+
+    generator->_as.inb();
+    return true;
+}
+
 symbol *
 zd4_builtins::get_procedure(zd4_generator *generator,
                             const ustring &name,

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -436,6 +436,16 @@ zd4_builtins::TworzPlik(zd4_generator *generator, const par::call_node &node)
 }
 
 bool
+zd4_builtins::UsunPlik(zd4_generator *generator, const par::call_node &node)
+{
+    REQUIRE(1 == node.arguments.size());
+
+    // INT 21,41 - Delete File
+    generator->_as.mov(cpu_register::ah, 0x41);
+    return file_operation(generator, *node.arguments.front());
+}
+
+bool
 zd::gen::zd4_builtins::ZmienKatalog(zd4_generator        *generator,
                                     const par::call_node &node)
 {

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -80,6 +80,16 @@ zd4_builtins::Czytaj(zd4_generator *generator, const par::call_node &node)
 }
 
 bool
+zd::gen::zd4_builtins::DoPortu(zd4_generator        *generator,
+                               const par::call_node &node)
+{
+    REQUIRE(node.is_bare);
+
+    generator->_as.outb();
+    return true;
+}
+
+bool
 zd4_builtins::Klawisz(zd4_generator *generator, const par::call_node &node)
 {
     // INT 21,7 - Direct Console Input Without Echo

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -492,9 +492,26 @@ bool
 zd::gen::zd4_builtins::StanPrzyciskow(zd4_generator        *generator,
                                       const par::call_node &node)
 {
+    REQUIRE(1 >= node.arguments.size());
+
     // INT 33,3 - Get Mouse Position and Button Status
     generator->_as.mov(cpu_register::ax, 3);
     generator->_as.intr(0x33);
+
+    if (1 == node.arguments.size())
+    {
+        REQUIRE(node.arguments.front()->is<string_node>());
+        auto &str = node.arguments.front()->as<string_node>()->value;
+        REQUIRE(1 == str.size());
+        REQUIRE('!' == *str.data());
+
+        generator->_as.mov(cpu_register::ax, cpu_register::cx);
+        generator->_as.mov(cpu_register::cl, 3);
+        generator->_as.shr(cpu_register::ax, cpu_register::cl);
+        generator->_as.shr(cpu_register::dx, cpu_register::cl);
+        generator->_as.mov(cpu_register::cx, cpu_register::ax);
+    }
+
     return true;
 }
 

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -526,6 +526,16 @@ zd4_builtins::TworzPlik(zd4_generator *generator, const par::call_node &node)
 }
 
 bool
+zd::gen::zd4_builtins::UkryjMysz(zd4_generator        *generator,
+                                 const par::call_node &node)
+{
+    // INT 33,2 - Hide Mouse Cursor
+    generator->_as.mov(cpu_register::ax, 2);
+    generator->_as.intr(0x33);
+    return true;
+}
+
+bool
 zd4_builtins::UsunKatalog(zd4_generator *generator, const par::call_node &node)
 {
     REQUIRE(1 == node.arguments.size());

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -403,7 +403,7 @@ zd4_builtins::PiszZnak(zd4_generator *generator, const call_node &node)
 
     // Number of repetitions
     uint16_t count{1};
-    if (1 < node.arguments.size())
+    if (2 < node.arguments.size())
     {
         it++;
         REQUIRE((*it)->is<number_node>());

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -419,6 +419,33 @@ zd4_builtins::Tryb(zd4_generator *generator, const par::call_node &node)
     return true;
 }
 
+bool
+zd4_builtins::TworzKatalog(zd4_generator *generator, const par::call_node &node)
+{
+    REQUIRE(1 == node.arguments.size());
+    REQUIRE(node.arguments.front()->is<string_node>());
+
+    auto &name = node.arguments.front()->as<string_node>()->value;
+
+    std::vector<char> data{};
+    data.resize(name.size() + 1);
+
+    auto ptr = data.data();
+    for (auto cp : name)
+    {
+        text::encoding::ibm852->encode(ptr, cp);
+        ptr++;
+    }
+    *ptr = 0;
+
+    // INT 21,39 - Create Subdirectory (mkdir)
+    generator->_as.mov(cpu_register::ah, 0x39);
+    generator->_as.mov(cpu_register::dx, data);
+    generator->_as.intr(0x21);
+
+    return true;
+}
+
 symbol *
 zd4_builtins::get_procedure(zd4_generator *generator,
                             const ustring &name,

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -550,6 +550,25 @@ zd4_builtins::UsunPlik(zd4_generator *generator, const par::call_node &node)
 }
 
 bool
+zd::gen::zd4_builtins::Zamknij(zd4_generator        *generator,
+                               const par::call_node &node)
+{
+    REQUIRE(1 == node.arguments.size());
+
+    REQUIRE(node.arguments.front()->is<subscript_node>());
+    auto subscript = node.arguments.front()->as<subscript_node>();
+    REQUIRE(subscript->value->is<number_node>());
+    auto fileno = subscript->value->as<number_node>()->value;
+
+    // INT 21,3E - Close File Using Handle
+    generator->_as.mov(cpu_register::ax, 0x3E);
+    generator->_as.mov(cpu_register::bx, fileno);
+    generator->_as.intr(0x21);
+
+    return true;
+}
+
+bool
 zd::gen::zd4_builtins::ZmienKatalog(zd4_generator        *generator,
                                     const par::call_node &node)
 {

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -436,6 +436,16 @@ zd4_builtins::TworzPlik(zd4_generator *generator, const par::call_node &node)
 }
 
 bool
+zd4_builtins::UsunKatalog(zd4_generator *generator, const par::call_node &node)
+{
+    REQUIRE(1 == node.arguments.size());
+
+    // INT 21,3A - Remove Subdirectory (rmdir)
+    generator->_as.mov(cpu_register::ah, 0x3A);
+    return file_operation(generator, *node.arguments.front());
+}
+
+bool
 zd4_builtins::UsunPlik(zd4_generator *generator, const par::call_node &node)
 {
     REQUIRE(1 == node.arguments.size());

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -432,6 +432,18 @@ zd4_builtins::Pozycja(zd4_generator *generator, const par::call_node &node)
 }
 
 bool
+zd::gen::zd4_builtins::Przerwanie(zd4_generator        *generator,
+                                  const par::call_node &node)
+{
+    REQUIRE(1 == node.arguments.size());
+    REQUIRE(node.arguments.front()->is<number_node>());
+
+    generator->_as.intr(node.arguments.front()->as<number_node>()->value);
+
+    return true;
+}
+
+bool
 zd4_builtins::Punkt(zd4_generator *generator, const par::call_node &node)
 {
     REQUIRE(3 == node.arguments.size());

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -436,6 +436,29 @@ zd4_builtins::TworzKatalog(zd4_generator *generator, const par::call_node &node)
     return true;
 }
 
+bool
+zd::gen::zd4_builtins::ZmienKatalog(zd4_generator        *generator,
+                                    const par::call_node &node)
+{
+    REQUIRE(1 == node.arguments.size());
+    REQUIRE(node.arguments.front()->is<string_node>());
+
+    auto &name = node.arguments.front()->as<string_node>()->value;
+
+    std::vector<char> data{};
+    data.resize(name.size() + 1);
+
+    auto ptr = name.encode(data.data(), text::encoding::ibm852);
+    *ptr = 0;
+
+    // INT 21,3B - Change Current Directory (chdir)
+    generator->_as.mov(cpu_register::ah, 0x3B);
+    generator->_as.mov(cpu_register::dx, data);
+    generator->_as.intr(0x21);
+
+    return true;
+}
+
 symbol *
 zd4_builtins::get_procedure(zd4_generator *generator,
                             const ustring &name,

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -152,6 +152,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::TworzPlik(this, node);
     }
 
+    if (text::pl_streqi("UkryjMysz", node.callee))
+    {
+        return zd4_builtins::UkryjMysz(this, node);
+    }
+
     if (text::pl_streqai("UsuńKatalog", node.callee))
     {
         return zd4_builtins::UsunKatalog(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -396,11 +396,6 @@ zd4_generator::process(const par::operation_node &node)
         if (node.left->is<object_node>() && node.right->is<number_node>())
         {
             auto left_obj = node.left->as<object_node>();
-            if (object_type::word != left_obj->type)
-            {
-                return false;
-            }
-
             auto &left_sym = get_symbol(left_obj->name);
             auto  right_num = node.right->as<number_node>();
             if (1 == right_num->value)

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -109,6 +109,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::TworzKatalog(this, node);
     }
 
+    if (text::pl_streqai("TwórzPlik", node.callee))
+    {
+        return zd4_builtins::TworzPlik(this, node);
+    }
+
     if (text::pl_streqai("ZmieńKatalog", node.callee))
     {
         return zd4_builtins::ZmienKatalog(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -117,6 +117,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Pozycja(this, node);
     }
 
+    if (text::pl_streqi("Przerwanie", node.callee))
+    {
+        return zd4_builtins::Przerwanie(this, node);
+    }
+
     if (text::pl_streqi("Punkt", node.callee))
     {
         return zd4_builtins::Punkt(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -253,6 +253,10 @@ zd4_generator::process(const par::declaration_node &node)
     symbol_type type{};
     switch (target->type)
     {
+    case object_type::byte:
+        type = symbol_type::var_byte;
+        break;
+
     case object_type::text:
         type = symbol_type::var_text;
         break;
@@ -269,6 +273,20 @@ zd4_generator::process(const par::declaration_node &node)
     unsigned address{};
     switch (type)
     {
+    case symbol_type::var_byte: {
+        if (zd4_section_udat == section)
+        {
+            address = _udat.reserve(sizeof(uint8_t));
+            break;
+        }
+
+        // Integer constant
+        number_node *num;
+        CAST_NODE_OR_FAIL(num, assignment->source);
+        address = _data.emit_byte(num->value);
+        break;
+    }
+
     case symbol_type::var_text: {
         if (zd4_section_udat == section)
         {

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -327,6 +327,13 @@ zd4_generator::process(const par::end_node &node)
 }
 
 bool
+zd::gen::zd4_generator::process(const par::emit_node &node)
+{
+    _curr_code->emit(node.bytes.data(), node.bytes.size());
+    return true;
+}
+
+bool
 zd4_generator::process(const par::jump_node &node)
 {
     label_node *label;

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -109,6 +109,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::TworzKatalog(this, node);
     }
 
+    if (text::pl_streqai("ZmieńKatalog", node.callee))
+    {
+        return zd4_builtins::ZmienKatalog(this, node);
+    }
+
     if (node.arguments.empty())
     {
         auto &symbol = get_symbol(node.callee);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -117,6 +117,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Pisz8(this, node);
     }
 
+    if (text::pl_streqai("PokażMysz", node.callee))
+    {
+        return zd4_builtins::PokazMysz(this, node);
+    }
+
     if (text::pl_streqi("Pozycja", node.callee))
     {
         return zd4_builtins::Pozycja(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -167,6 +167,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Zamknij(this, node);
     }
 
+    if (text::pl_streqai("ZPortu", node.callee))
+    {
+        return zd4_builtins::ZPortu(this, node);
+    }
+
     if (node.arguments.empty())
     {
         auto &symbol = get_symbol(node.callee);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -72,6 +72,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Czytaj(this, node);
     }
 
+    if (text::pl_streqi("DoPortu", node.callee))
+    {
+        return zd4_builtins::DoPortu(this, node);
+    }
+
     if (text::pl_streqi("Klawisz", node.callee))
     {
         return zd4_builtins::Klawisz(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -134,6 +134,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::ZmienKatalog(this, node);
     }
 
+    if (text::pl_streqai("Zamknij", node.callee))
+    {
+        return zd4_builtins::Zamknij(this, node);
+    }
+
     if (node.arguments.empty())
     {
         auto &symbol = get_symbol(node.callee);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -114,6 +114,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::TworzPlik(this, node);
     }
 
+    if (text::pl_streqai("UsuńPlik", node.callee))
+    {
+        return zd4_builtins::UsunPlik(this, node);
+    }
+
     if (text::pl_streqai("ZmieńKatalog", node.callee))
     {
         return zd4_builtins::ZmienKatalog(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -212,12 +212,7 @@ zd4_generator::process(const par::declaration_node &node)
         auto ptr = data.data();
         *(ptr++) = str->value.size() + 2;
         *(ptr++) = str->value.size() + 2;
-
-        for (auto cp : str->value)
-        {
-            text::encoding::ibm852->encode(ptr, cp);
-            ptr++;
-        }
+        ptr = str->value.encode(ptr, text::encoding::ibm852);
         *(ptr++) = 0;
         *ptr = '$';
 

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -64,6 +64,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Losowa16(this, node);
     }
 
+    if (text::pl_streqai("Otwórz", node.callee))
+    {
+        return zd4_builtins::Otworz(this, node);
+    }
+
     if (text::pl_streqi("Losowa8", node.callee))
     {
         return zd4_builtins::Losowa8(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -114,6 +114,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::TworzPlik(this, node);
     }
 
+    if (text::pl_streqai("UsuńKatalog", node.callee))
+    {
+        return zd4_builtins::UsunKatalog(this, node);
+    }
+
     if (text::pl_streqai("UsuńPlik", node.callee))
     {
         return zd4_builtins::UsunPlik(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -104,6 +104,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Tryb(this, node);
     }
 
+    if (text::pl_streqai("TwórzKatalog", node.callee))
+    {
+        return zd4_builtins::TworzKatalog(this, node);
+    }
+
     if (node.arguments.empty())
     {
         auto &symbol = get_symbol(node.callee);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -137,6 +137,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Punkt(this, node);
     }
 
+    if (text::pl_streqai("StanPrzycisków", node.callee))
+    {
+        return zd4_builtins::StanPrzyciskow(this, node);
+    }
+
     if (text::pl_streqi("Tryb", node.callee))
     {
         return zd4_builtins::Tryb(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -23,14 +23,32 @@ using namespace zd::par;
 bool
 zd4_generator::process(const par::assignment_node &node)
 {
-    object_node *target;
-    CAST_NODE_OR_FAIL(target, node.target);
-
-    auto &dst = get_symbol(target->name);
-    if (node.source->is<number_node>())
+    if (node.target->is<object_node>())
     {
-        _as.mov(dst, (uint16_t)node.source->as<number_node>()->value);
-        return true;
+        auto  target = node.target->as<object_node>();
+        auto &dst = get_symbol(target->name);
+
+        if (node.source->is<number_node>())
+        {
+            _as.mov(dst, (uint16_t)node.source->as<number_node>()->value);
+            return true;
+        }
+
+        return false;
+    }
+
+    if (node.target->is<register_node>())
+    {
+        auto target = node.target->as<register_node>();
+        auto dst = target->reg;
+
+        if (node.source->is<number_node>())
+        {
+            _as.mov(dst, (uint16_t)node.source->as<number_node>()->value);
+            return true;
+        }
+
+        return false;
     }
 
     return false;

--- a/zdc/src/zd/ustring.cpp
+++ b/zdc/src/zd/ustring.cpp
@@ -67,6 +67,17 @@ ustring::operator=(ustring &&that) noexcept
     return *this;
 }
 
+char *
+zd::ustring::encode(char *dst, text::encoding *enc) const
+{
+    for (auto cp : *this)
+    {
+        dst += enc->encode(dst, cp);
+    }
+
+    return dst;
+}
+
 bool
 ustring::reserve(size_t new_cap)
 {


### PR DESCRIPTION
Ogólne:
- dodaj metodę `ustring::encode`

ZD4:
- obsłuż `TwórzKatalog`, `ZmieńKatalog`, `TwórzPlik`, `UsuńPlik`, `UsuńKatalog`, `Otwórz`, `Pisz` i `PiszL` do pliku i  `Zamknij` (zgodność: LEKCJA08)
-  `Punkt` ze stałymi liczbowymi, przypisanie stałej do rejestru, `Przerwanie`, `DoPortu`, `ZPortu` i dyrektywę `#,` (zgodność: LEKCJA09, ZADANIA)
- obsłuż `PokażMysz`, `UkryjMysz`, `StanPrzycisków`, porównania z liczbą rejestrów innych niż A, jedno- i dwuargumentowe `PiszZnak` i zmienne bajtowe (zgodność: LEKCJA10)
- zaktualizuj listę sprawnych przykładów