### PR TITLE
Generuj przykłady z folderów INC i PRZYKLAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | DOWCIPY | ✅ | ✅ | ✅ |
 | GRA | ✅ | ✅ | ✅ |
 | KWADRAT | ✅ | ✅ | ✅ |
-| LINIA | ✅ | ✅ |
+| LINIA | ✅ | ✅ | ✅ |
 | PETLE | ✅ | ✅ | ✅ |
 | ZC | ✅ | ✅ |
 | !TLO | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | DZWIEK2 | ✅ | ✅ |
 | KLAWIAT | ✅ | ✅ |
 | MYSZ | ✅ | ✅ |
-| SAVER | ✅ | ✅ |
+| SAVER | ✅ | ✅ | ⚠️[^1] |
 | **PRZYKLAD** | - | - | - |
 | DOWCIPY | ✅ | ✅ | ✅ |
 | GRA | ✅ | ✅ | ✅ |
 | KWADRAT | ✅ | ✅ | ✅ |
 | LINIA | ✅ | ✅ | ✅ |
 | PETLE | ✅ | ✅ | ✅ |
-| ZC | ✅ | ✅ | ⚠️[^1] |
+| ZC | ✅ | ✅ | ⚠️[^2] |
 | !TLO | ✅ | ✅ | ✅ |
 | ALARM | ✅ | ✅ | ✅ |
 | ASCII | ✅ | ✅ | ✅ |
 | COOL-GR1 | ✅ | ✅ | ✅ |
-| DEMO | ✅ | ✅ | ⚠️[^2] |
+| DEMO | ✅ | ✅ | ⚠️[^3] |
 | DZWIEK | ✅ | ✅ | ✅ |
 | EFEKT | ✅ | ✅ | ✅ |
 | LOSOWE | ✅ | ✅ | ✅ |
@@ -60,5 +60,6 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | TESTMYSZ | ✅ | ✅ | ✅ |
 | WSTAW | ✅ | ✅ | ✅ |
 
-[^1]: Wiodące spacje utracone w nieregularnych ciągach tekstowych.
-[^2]: Wymagana zmiana zduplikowanej nazwy.
+[^1]: Wymagane dostosowanie do skompilowanego przykładu dołączonego do ZDZICH5.
+[^2]: Wiodące spacje utracone w nieregularnych ciągach tekstowych.
+[^3]: Wymagana zmiana zduplikowanej nazwy.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | KWADRAT | ✅ | ✅ | ✅ |
 | LINIA | ✅ | ✅ | ✅ |
 | PETLE | ✅ | ✅ | ✅ |
-| ZC | ✅ | ✅ |
+| ZC | ✅ | ✅ | ⚠️[^1] |
 | !TLO | ✅ | ✅ | ✅ |
 | ALARM | ✅ | ✅ | ✅ |
 | ASCII | ✅ | ✅ |
@@ -59,3 +59,5 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | SKOKI | ✅ | ✅ | ✅ |
 | TESTMYSZ | ✅ | ✅ | ✅ |
 | WSTAW | ✅ | ✅ | ✅ |
+
+[^1]: Wiodące spacje utracone w nieregularnych ciągach tekstowych.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | ALARM | ✅ | ✅ | ✅ |
 | ASCII | ✅ | ✅ | ✅ |
 | COOL-GR1 | ✅ | ✅ | ✅ |
-| DEMO | ✅ | ✅ |
+| DEMO | ✅ | ✅ | ⚠️[^2] |
 | DZWIEK | ✅ | ✅ | ✅ |
 | EFEKT | ✅ | ✅ | ✅ |
 | LOSOWE | ✅ | ✅ |
@@ -61,3 +61,4 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | WSTAW | ✅ | ✅ | ✅ |
 
 [^1]: Wiodące spacje utracone w nieregularnych ciągach tekstowych.
+[^2]: Wymagana zmiana zduplikowanej nazwy.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | DEMO | ✅ | ✅ | ⚠️[^2] |
 | DZWIEK | ✅ | ✅ | ✅ |
 | EFEKT | ✅ | ✅ | ✅ |
-| LOSOWE | ✅ | ✅ |
+| LOSOWE | ✅ | ✅ | ✅ |
 | MYSZ | ✅ | ✅ | ✅ |
 | MYSZKA | ✅ | ✅ | ✅ |
 | MYSZRYS | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | MYSZKA | ✅ | ✅ | ✅ |
 | MYSZRYS | ✅ | ✅ | ✅ |
 | PARAMETR | ✅ | ✅ | ✅ |
-| PLIKI1 | ✅ | ✅ |
-| PLIKI2 | ✅ | ✅ |
+| PLIKI1 | ✅ | ✅ | ✅ |
+| PLIKI2 | ✅ | ✅ | ✅ |
 | SKOKI | ✅ | ✅ | ✅ |
 | TESTMYSZ | ✅ | ✅ | ✅ |
 | WSTAW | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | ZC | ✅ | ✅ | ⚠️[^1] |
 | !TLO | ✅ | ✅ | ✅ |
 | ALARM | ✅ | ✅ | ✅ |
-| ASCII | ✅ | ✅ |
+| ASCII | ✅ | ✅ | ✅ |
 | COOL-GR1 | ✅ | ✅ | ✅ |
 | DEMO | ✅ | ✅ |
 | DZWIEK | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | MYSZ | ✅ | ✅ | ✅ |
 | MYSZKA | ✅ | ✅ | ✅ |
 | MYSZRYS | ✅ | ✅ | ✅ |
-| PARAMETR | ✅ | ✅ |
+| PARAMETR | ✅ | ✅ | ✅ |
 | PLIKI1 | ✅ | ✅ |
 | PLIKI2 | ✅ | ✅ |
 | SKOKI | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | **INC** | - | - | - |
 | DOGIER | ✅ | ✅ | ✅ |
 | DZWIEK | ✅ | ✅ | ✅ |
-| DZWIEK2 | ✅ | ✅ |
-| KLAWIAT | ✅ | ✅ |
-| MYSZ | ✅ | ✅ |
+| DZWIEK2 | ✅ | ✅ | ✅ |
+| KLAWIAT | ✅ | ✅ | ✅ |
+| MYSZ | ✅ | ✅ | ✅ |
 | SAVER | ✅ | ✅ | ⚠️[^1] |
 | **PRZYKLAD** | - | - | - |
 | DOWCIPY | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | LEKCJA11 | ✅ | ✅ | ✅ |
 | ZADANIA | ✅ | ✅ | ✅ |
 | **INC** | - | - | - |
-| DOGIER | ✅ | ✅ |
+| DOGIER | ✅ | ✅ | ✅ |
 | DZWIEK | ✅ | ✅ | ✅ |
 | DZWIEK2 | ✅ | ✅ |
 | KLAWIAT | ✅ | ✅ |
@@ -37,7 +37,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | SAVER | ✅ | ✅ |
 | **PRZYKLAD** | - | - | - |
 | DOWCIPY | ✅ | ✅ | ✅ |
-| GRA | ✅ | ✅ |
+| GRA | ✅ | ✅ | ✅ |
 | KWADRAT | ✅ | ✅ | ✅ |
 | LINIA | ✅ | ✅ |
 | PETLE | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Niniejsze repozytorium ma na celu wskrzeszenie tego projektu - w szczególności
 | MYSZ | ✅ | ✅ |
 | SAVER | ✅ | ✅ |
 | **PRZYKLAD** | - | - | - |
-| DOWCIPY | ✅ | ✅ |
+| DOWCIPY | ✅ | ✅ | ✅ |
 | GRA | ✅ | ✅ |
 | KWADRAT | ✅ | ✅ | ✅ |
 | LINIA | ✅ | ✅ |

--- a/sample/INC/SAVER/SAVER.INC
+++ b/sample/INC/SAVER/SAVER.INC
@@ -36,9 +36,9 @@ Porownaj BX,0
 * Ruch myszy
 %PX1=CX
 %PY1=DX
-Porownaj %PX1,%PX2
+Porownaj %PX1,0
 &Skok :Ruchm
-Porownaj %PY1,%PY2
+Porownaj %PY1,0
 &Skok :Ruchm
 Skok :dal5
 :Ruchm
@@ -58,8 +58,8 @@ Koniec KONIEC()
 
 Procedura CZYKLAWISZ()
 * Jesli nacisnoles klawisz, to ta procedura konczy program
-  czekaj 4
-  OPROZNIJBUFOR()
+  AH=$0B
+  PRZERWANIE $21
   POROWNAJ AL,0
   <>SKOK :KON
   Skok :CD

--- a/sample/PRZYKLAD/DEMO.ZDI
+++ b/sample/PRZYKLAD/DEMO.ZDI
@@ -27,7 +27,7 @@ Pozycja 7,20
 Pisz Nacisnij dowolny klawisz...
 Klawisz
 Czyûç 31
-IMIê()
+CZYTAJIMIE()
 Klawisz
 Tryb 0
 Czyûç 52
@@ -94,10 +94,10 @@ Zamknij #5
 PiszL Zobacz plik DEMO.TXT w tym katalogu!!!
 Koniec
 
-Procedura IMIê()
+Procedura CZYTAJIMIE()
 	PiszL Jak masz na imie?
 	Czytaj $Imië
 	Pisz $Tekst
 	Pisz $Imië
 	PiszL !!!
-Koniec IMIê()
+Koniec CZYTAJIMIE()

--- a/sample/idzwiek2.zdi
+++ b/sample/idzwiek2.zdi
@@ -1,0 +1,44 @@
+* Polski język programowania Zdzich
+* Program testowy dla biblioteki dźwiękowej do języka programowania ZDZICH 4
+* 2024 Mateusz Karcz
+
+AUTOR()
+
+GLOS()
+Czekaj 5
+CISZA()
+Klawisz
+
+DZWIEK1()
+Klawisz
+
+DZWIEK2()
+Klawisz
+
+DZWIEK3()
+Klawisz
+
+DZWIEK4()
+Klawisz
+
+DZWIEK5()
+Klawisz
+
+DZWIEK6()
+Klawisz
+
+DZWIEK7()
+Klawisz
+
+DZWIEK8()
+Klawisz
+
+DZWIEK9()
+Klawisz
+
+DZWIEK10()
+Klawisz
+
+Koniec
+
+#Wstaw INC\DZWIEK2.INC

--- a/sample/iklawiat.zdi
+++ b/sample/iklawiat.zdi
@@ -1,0 +1,29 @@
+* Polski język programowania Zdzich
+* Program testowy dla biblioteki obsługi klawiatury do ZDZICHa 4
+* 2024 Mateusz Karcz
+
+AUTOR()
+
+Pisz Naciśnij spację... 
+SPACJA()
+PiszL spacja!
+
+Pisz Naciśnij Enter... 
+ENTER()
+PiszL Enter!
+
+Pisz Naciśnij spację lub Esc... 
+SPACJAESC()
+PiszL spacja!
+
+Pisz Naciśnij Enter lub Esc... 
+ENTERESC()
+PiszL Enter!
+
+Pisz Naciśnij dowolny klawisz... 
+ESC()
+PiszL nie Esc!
+
+Koniec
+
+#Wstaw INC\KLAWIAT.INC

--- a/sample/imysz.zdi
+++ b/sample/imysz.zdi
@@ -1,0 +1,21 @@
+* Polski język programowania Zdzich
+* Program testowy dla biblioteki do obsługi MYSZY
+* 2024 Mateusz Karcz
+
+AUTOR()
+
+Pisz Naciśnij lewy przycisk myszy... 
+LEWY()
+PiszL ok!
+
+Pisz Naciśnij prawy przycisk myszy... 
+PRAWY()
+PiszL ok!
+
+Pisz Naciśnij oba przyciski myszy... 
+OBYDWA()
+PiszL ok!
+
+Koniec
+
+#Wstaw INC\MYSZ.INC

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -112,6 +112,9 @@ class x86_assembler
     jne(const symbol_ref &target);
 
     bool
+    lodsb();
+
+    bool
     mov(par::cpu_register dst, par::cpu_register src);
 
     bool

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -160,7 +160,13 @@ class x86_assembler
     pop(x86_segment seg);
 
     bool
+    pop(const symbol_ref &dst);
+
+    bool
     push(x86_segment seg);
+
+    bool
+    push(const symbol_ref &src);
 
     bool
     stc();

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -97,6 +97,9 @@ class x86_assembler
     cmp(par::cpu_register left, unsigned right);
 
     bool
+    cmp(par::cpu_register left, const symbol_ref &right);
+
+    bool
     cmp(const symbol_ref &left, uint16_t right);
 
     bool

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -148,6 +148,9 @@ class x86_assembler
     push(x86_segment seg);
 
     bool
+    add(par::cpu_register dst, unsigned src);
+
+    bool
     add(par::cpu_register dst, par::cpu_register src);
 
     bool

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -85,6 +85,15 @@ class x86_assembler
     call(const symbol_ref &target);
 
     bool
+    clc();
+
+    bool
+    cld();
+
+    bool
+    cli();
+
+    bool
     cmp(par::cpu_register left, unsigned right);
 
     bool
@@ -149,6 +158,15 @@ class x86_assembler
 
     bool
     push(x86_segment seg);
+
+    bool
+    stc();
+
+    bool
+    std();
+
+    bool
+    sti();
 
     bool
     add(par::cpu_register dst, unsigned src);

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -126,6 +126,9 @@ class x86_assembler
     mov(par::cpu_register dst, unsigned src);
 
     bool
+    nop();
+
+    bool
     outb();
 
     bool

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -45,6 +45,16 @@ struct symbol_ref
     }
 };
 
+enum class x86_segment
+{
+    cs,
+    ss,
+    ds,
+    es,
+    fs,
+    gs
+};
+
 struct mreg
 {
     par::cpu_register reg;
@@ -130,6 +140,12 @@ class x86_assembler
 
     bool
     outb();
+
+    bool
+    pop(x86_segment seg);
+
+    bool
+    push(x86_segment seg);
 
     bool
     add(par::cpu_register dst, par::cpu_register src);

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -117,6 +117,11 @@ struct zd4_builtins
     load_numeric_argument(zd4_generator    *generator,
                           par::cpu_register reg,
                           par::node        &arg);
+
+    static bool
+    load_textual_argument(zd4_generator    *generator,
+                          par::cpu_register reg,
+                          par::node        &arg);
 };
 
 } // namespace gen

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -92,6 +92,9 @@ struct zd4_builtins
     ZmienKatalog(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    ZmienNazwe(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     ZPortu(zd4_generator *generator, const par::call_node &node);
 
   private:

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -35,6 +35,9 @@ struct zd4_builtins
     Losowa8(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    Nic(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Otworz(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -29,6 +29,9 @@ struct zd4_builtins
     Klawisz(zd4_generator *generator, const par::call_node &node);
 
     static bool
+    Laduj(zd4_generator *generator, const par::call_node &node);
+
+    static bool
     Losowa16(zd4_generator *generator, const par::call_node &node);
 
     static bool

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -110,6 +110,11 @@ struct zd4_builtins
     static bool
     Pisz(zd4_generator *generator, unsigned fileno, const ustring &str);
 
+    static bool
+    Pisz(zd4_generator          *generator,
+         unsigned                fileno,
+         const par::object_node &obj);
+
     static symbol *
     get_procedure(zd4_generator *generator,
                   const ustring &name,

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -34,6 +34,7 @@
 #define ModRM_DIBH         0xC7
 
 #define ADD_r16_rm16   0x03
+#define ADD_rm8_imm8   0x80 // RegOpcode 0
 #define ADD_rm16_imm16 0x81 // RegOpcode 0
 
 #define CALL_rel16 0xE8

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -72,6 +72,8 @@
 #define MOV_rm8_imm8    0xC6
 #define MOV_rm16_imm16  0xC7
 
+#define NOP 0x90
+
 #define OUT_DX_AL 0xEE
 
 #define RET_near 0xC3

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -49,6 +49,8 @@
 #define CMP_rm8_imm8   0x80 // RegOpcode 7
 #define CMP_AX_imm16   0x3D
 #define CMP_rm16_imm16 0x81 // RegOpcode 7
+#define CMP_r8_rm8     0x3A
+#define CMP_r16_rm16   0x3B
 
 #define DEC_rm16 0xFF // RegOpcode 1
 

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -64,6 +64,8 @@
 #define JNE_rel8  0x75
 #define JNE_rel16 0x850F
 
+#define LODS_m8 0xAC
+
 #define MOV_rm8_r8      0x88
 #define MOV_rm16_r16    0x89
 #define MOV_r8_rm8      0x8A

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -39,6 +39,12 @@
 
 #define CALL_rel16 0xE8
 
+#define CLC 0xF8
+
+#define CLD 0xFC
+
+#define CLI 0xFA
+
 #define CMP_AL_imm8    0x3C
 #define CMP_rm8_imm8   0x80 // RegOpcode 7
 #define CMP_AX_imm16   0x3D
@@ -95,6 +101,12 @@
 #define RET_near 0xC3
 
 #define SHR_rm16_CL 0xD3 // RegOpcode 5
+
+#define STC 0xF9
+
+#define STD 0xFD
+
+#define STI 0xFB
 
 #define SUB_rm16_imm16 0x81 // RegOpcode 5
 

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -76,6 +76,19 @@
 
 #define OUT_DX_AL 0xEE
 
+#define POP_DS 0x1F
+#define POP_ES 0x07
+#define POP_SS 0x17
+#define POP_FS 0xA10F
+#define POP_GS 0xA90F
+
+#define PUSH_CS 0x0E
+#define PUSH_SS 0x16
+#define PUSH_DS 0x1E
+#define PUSH_ES 0x06
+#define PUSH_FS 0xA00F
+#define PUSH_GS 0xA80F
+
 #define RET_near 0xC3
 
 #define SHR_rm16_CL 0xD3 // RegOpcode 5

--- a/zdc/src/zd/gen/opcodes.hpp
+++ b/zdc/src/zd/gen/opcodes.hpp
@@ -87,18 +87,20 @@
 
 #define OUT_DX_AL 0xEE
 
-#define POP_DS 0x1F
-#define POP_ES 0x07
-#define POP_SS 0x17
-#define POP_FS 0xA10F
-#define POP_GS 0xA90F
+#define POP_m16 0x8F // RegOpcode 0
+#define POP_DS  0x1F
+#define POP_ES  0x07
+#define POP_SS  0x17
+#define POP_FS  0xA10F
+#define POP_GS  0xA90F
 
-#define PUSH_CS 0x0E
-#define PUSH_SS 0x16
-#define PUSH_DS 0x1E
-#define PUSH_ES 0x06
-#define PUSH_FS 0xA00F
-#define PUSH_GS 0xA80F
+#define PUSH_m16 0xFF // RegOpcode 6
+#define PUSH_CS  0x0E
+#define PUSH_SS  0x16
+#define PUSH_DS  0x1E
+#define PUSH_ES  0x06
+#define PUSH_FS  0xA00F
+#define PUSH_GS  0xA80F
 
 #define RET_near 0xC3
 

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -362,6 +362,13 @@ x86_assembler::mov(par::cpu_register dst, unsigned src)
 }
 
 bool
+x86_assembler::nop()
+{
+    _code->emit_byte(NOP);
+    return true;
+}
+
+bool
 x86_assembler::outb()
 {
     _code->emit_byte(OUT_DX_AL);

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -253,6 +253,13 @@ x86_assembler::jne(const symbol_ref &target)
 }
 
 bool
+x86_assembler::lodsb()
+{
+    _code->emit_byte(LODS_m8);
+    return true;
+}
+
+bool
 x86_assembler::mov(par::cpu_register dst, par::cpu_register src)
 {
     ASM_REQUIRE(_reg_size(src) == _reg_size(dst));

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -456,6 +456,15 @@ zd::gen::x86_assembler::pop(x86_segment seg)
 }
 
 bool
+x86_assembler::pop(const symbol_ref &dst)
+{
+    _code->emit_byte(POP_m16);
+    _code->emit_byte(ModRM(ModRM_disp16, 0));
+    _code->emit_ref({dst.sym.address, dst.sym.section, dst.off});
+    return true;
+}
+
+bool
 zd::gen::x86_assembler::push(x86_segment seg)
 {
     switch (seg)
@@ -486,6 +495,15 @@ zd::gen::x86_assembler::push(x86_segment seg)
     }
 
     return false;
+}
+
+bool
+x86_assembler::push(const symbol_ref &dst)
+{
+    _code->emit_byte(PUSH_m16);
+    _code->emit_byte(ModRM(ModRM_disp16, 6));
+    _code->emit_ref({dst.sym.address, dst.sym.section, dst.off});
+    return true;
 }
 
 bool

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -439,6 +439,28 @@ zd::gen::x86_assembler::push(x86_segment seg)
 }
 
 bool
+x86_assembler::add(par::cpu_register dst, unsigned src)
+{
+    if (sizeof(uint8_t) == _reg_size(dst))
+    {
+        _code->emit_byte(ADD_rm8_imm8);
+        _code->emit_byte(ModRM(_to_mode(dst), 0));
+        _code->emit_byte(src);
+        return true;
+    }
+
+    if (sizeof(uint16_t) == _reg_size(dst))
+    {
+        _code->emit_byte(ADD_rm16_imm16);
+        _code->emit_byte(ModRM(_to_mode(dst), 0));
+        _code->emit_word(src);
+        return true;
+    }
+
+    return false;
+}
+
+bool
 x86_assembler::add(par::cpu_register dst, par::cpu_register src)
 {
     ASM_REQUIRE(_reg_size(dst) == _reg_size(src));
@@ -462,7 +484,12 @@ x86_assembler::add(const symbol_ref &dst, unsigned src)
 bool
 x86_assembler::inc(par::cpu_register reg)
 {
-    ASM_REQUIRE(sizeof(uint16_t) == _reg_size(reg));
+    if (sizeof(uint8_t) == _reg_size(reg))
+    {
+        _code->emit_byte(INC_rm8);
+        _code->emit_byte(ModRM(_to_mode(reg), 0));
+        return true;
+    }
 
     _code->emit_byte(INC_r16 | _to_regopcode(reg));
     return true;

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -199,6 +199,28 @@ x86_assembler::cmp(par::cpu_register left, unsigned right)
 }
 
 bool
+x86_assembler::cmp(par::cpu_register left, const symbol_ref &right)
+{
+    if (sizeof(uint8_t) == _reg_size(left))
+    {
+        _code->emit_byte(CMP_r8_rm8);
+        _code->emit_byte(ModRM(ModRM_disp16, _to_regopcode(left)));
+        _code->emit_ref({right.sym.address, right.sym.section});
+        return true;
+    }
+
+    if (sizeof(uint16_t) == _reg_size(left))
+    {
+        _code->emit_byte(CMP_r16_rm16);
+        _code->emit_byte(ModRM(ModRM_disp16, _to_regopcode(left)));
+        _code->emit_ref({right.sym.address, right.sym.section});
+        return true;
+    }
+
+    return false;
+}
+
+bool
 x86_assembler::cmp(mreg left, unsigned right)
 {
     if (sizeof(uint16_t) == _reg_size(left.reg))

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -212,7 +212,8 @@ x86_assembler::inb()
 bool
 x86_assembler::cmp(const symbol_ref &left, uint16_t right)
 {
-    _code->emit_byte(CMP_rm16_imm16);
+    _code->emit_byte((symbol_type::var_byte == left.sym.type) ? CMP_rm8_imm8
+                                                              : CMP_rm16_imm16);
     _code->emit_byte(ModRM(ModRM_disp16, 7));
     _code->emit_ref({left.sym.address, left.sym.section, left.off});
     _code->emit_word(right);

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -377,6 +377,68 @@ x86_assembler::outb()
 }
 
 bool
+zd::gen::x86_assembler::pop(x86_segment seg)
+{
+    switch (seg)
+    {
+    case x86_segment::ds:
+        _code->emit_byte(POP_DS);
+        return true;
+
+    case x86_segment::es:
+        _code->emit_byte(POP_ES);
+        return true;
+
+    case x86_segment::ss:
+        _code->emit_byte(POP_SS);
+        return true;
+
+    case x86_segment::fs:
+        _code->emit_word(POP_FS);
+        return true;
+
+    case x86_segment::gs:
+        _code->emit_word(POP_GS);
+        return true;
+    }
+
+    return false;
+}
+
+bool
+zd::gen::x86_assembler::push(x86_segment seg)
+{
+    switch (seg)
+    {
+    case x86_segment::cs:
+        _code->emit_byte(PUSH_CS);
+        return true;
+
+    case x86_segment::ss:
+        _code->emit_byte(PUSH_SS);
+        return true;
+
+    case x86_segment::ds:
+        _code->emit_byte(PUSH_DS);
+        return true;
+
+    case x86_segment::es:
+        _code->emit_byte(PUSH_ES);
+        return true;
+
+    case x86_segment::fs:
+        _code->emit_word(PUSH_FS);
+        return true;
+
+    case x86_segment::gs:
+        _code->emit_word(PUSH_GS);
+        return true;
+    }
+
+    return false;
+}
+
+bool
 x86_assembler::add(par::cpu_register dst, par::cpu_register src)
 {
     ASM_REQUIRE(_reg_size(dst) == _reg_size(src));

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -138,6 +138,27 @@ x86_assembler::call(const symbol_ref &target)
 }
 
 bool
+x86_assembler::clc()
+{
+    _code->emit_byte(CLC);
+    return true;
+}
+
+bool
+x86_assembler::cld()
+{
+    _code->emit_byte(CLD);
+    return true;
+}
+
+bool
+x86_assembler::cli()
+{
+    _code->emit_byte(CLI);
+    return true;
+}
+
+bool
 x86_assembler::cmp(par::cpu_register left, unsigned right)
 {
     if (sizeof(uint8_t) == _reg_size(left))
@@ -443,6 +464,27 @@ zd::gen::x86_assembler::push(x86_segment seg)
     }
 
     return false;
+}
+
+bool
+x86_assembler::stc()
+{
+    _code->emit_byte(STC);
+    return true;
+}
+
+bool
+x86_assembler::std()
+{
+    _code->emit_byte(STD);
+    return true;
+}
+
+bool
+x86_assembler::sti()
+{
+    _code->emit_byte(STI);
+    return true;
 }
 
 bool

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -424,16 +424,17 @@ zd4_builtins::PiszZnak(zd4_generator *generator, const call_node &node)
 
     // Character code
     auto it = node.arguments.begin();
-    REQUIRE((*it)->is<number_node>());
-    uint8_t character = (*it)->as<number_node>()->value;
+    REQUIRE(load_numeric_argument(generator, cpu_register::al, **it));
 
     // Display attribute (colors)
-    uint8_t attribute{7};
     if (1 < node.arguments.size())
     {
         it++;
-        REQUIRE((*it)->is<number_node>());
-        attribute = (*it)->as<number_node>()->value;
+        REQUIRE(load_numeric_argument(generator, cpu_register::bl, **it));
+    }
+    else
+    {
+        generator->_as.mov(cpu_register::bl, 0x0007);
     }
 
     // Number of repetitions
@@ -441,14 +442,16 @@ zd4_builtins::PiszZnak(zd4_generator *generator, const call_node &node)
     if (2 < node.arguments.size())
     {
         it++;
-        REQUIRE((*it)->is<number_node>());
-        count = (*it)->as<number_node>()->value;
+        REQUIRE(load_numeric_argument(generator, cpu_register::cx, **it));
+    }
+    else
+    {
+        generator->_as.mov(cpu_register::cx, 1);
     }
 
     // INT 10,9 - Write Character and Attribute at Cursor Position
-    generator->_as.mov(cpu_register::ax, 0x0900 | character);
-    generator->_as.mov(cpu_register::bx, attribute);
-    generator->_as.mov(cpu_register::cx, count);
+    generator->_as.mov(cpu_register::ah, 0x09);
+    generator->_as.mov(cpu_register::bh, 0);
     generator->_as.intr(0x10);
 
     return true;

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -446,13 +446,20 @@ static const uint8_t Pisz8_impl[]{
 bool
 zd4_builtins::Pisz8(zd4_generator *generator, const call_node &node)
 {
-    REQUIRE(1 == node.arguments.size());
+    if (!node.is_bare)
+    {
+        REQUIRE(1 == node.arguments.size());
+    }
 
     auto procedure =
         get_procedure(generator, "$Pisz8", Pisz8_impl, sizeof(Pisz8_impl));
     REQUIRE(procedure);
 
-    if (node.arguments.front()->is<register_node>())
+    if (node.is_bare)
+    {
+        generator->_as.mov(cpu_register::cl, cpu_register::al);
+    }
+    else if (node.arguments.front()->is<register_node>())
     {
         auto reg = node.arguments.front()->as<register_node>();
         generator->_as.mov(cpu_register::cl, reg->reg);

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -435,11 +435,11 @@ zd4_builtins::Pisz8(zd4_generator *generator, const call_node &node)
     {
         REQUIRE(node.arguments.front()->is<object_node>());
 
-        auto num = node.arguments.front()->as<object_node>();
-        REQUIRE(object_type::word == num->type);
-
-        auto &symbol = generator->get_symbol(num->name);
-        generator->_as.mov(cpu_register::bx, symbol_ref{symbol});
+        auto  obj = node.arguments.front()->as<object_node>();
+        auto &symbol = generator->get_symbol(obj->name);
+        generator->_as.mov(
+            cpu_register::bx,
+            symbol_ref{symbol, (object_type::text == obj->type) ? +2 : 0});
         generator->_as.mov(cpu_register::cl, mreg{cpu_register::bx});
     }
 

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -294,6 +294,21 @@ zd4_builtins::Pisz(zd4_generator *generator, const call_node &node)
 
     if ((*it)->is<string_node>())
     {
+        if (1 < node.arguments.size())
+        {
+            ustring value{(*it)->as<string_node>()->value};
+
+            it++;
+            while (node.arguments.end() != it)
+            {
+                REQUIRE((*it)->is<string_node>());
+                value.append((*it)->as<string_node>()->value);
+                it++;
+            }
+
+            return Pisz(generator, value);
+        }
+
         return Pisz(generator, (*it)->as<string_node>()->value);
     }
 
@@ -345,6 +360,23 @@ zd4_builtins::PiszL(zd4_generator *generator, const call_node &node)
 
     if ((*it)->is<string_node>())
     {
+        if (1 < node.arguments.size())
+        {
+            ustring value{(*it)->as<string_node>()->value};
+
+            it++;
+            while (node.arguments.end() != it)
+            {
+                REQUIRE((*it)->is<string_node>());
+                value.append((*it)->as<string_node>()->value);
+                it++;
+            }
+            value.append('\r');
+            value.append('\n');
+
+            return Pisz(generator, value);
+        }
+
         ustring value{(*it)->as<string_node>()->value};
         value.append('\r');
         value.append('\n');

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -613,7 +613,7 @@ zd::gen::zd4_builtins::Zamknij(zd4_generator        *generator,
     auto fileno = subscript->value->as<number_node>()->value;
 
     // INT 21,3E - Close File Using Handle
-    generator->_as.mov(cpu_register::ax, 0x3E);
+    generator->_as.mov(cpu_register::ah, 0x3E);
     generator->_as.mov(cpu_register::bx, fileno);
     generator->_as.intr(0x21);
 

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -682,6 +682,27 @@ zd::gen::zd4_builtins::ZmienKatalog(zd4_generator        *generator,
 }
 
 bool
+zd::gen::zd4_builtins::ZmienNazwe(zd4_generator        *generator,
+                                  const par::call_node &node)
+{
+    REQUIRE(2 == node.arguments.size());
+
+    auto it = node.arguments.begin();
+    REQUIRE(load_textual_argument(generator, cpu_register::dx, **it));
+
+    it++;
+    REQUIRE(load_textual_argument(generator, cpu_register::di, **it));
+
+    // INT 21,56 - Rename File
+    generator->_as.push(x86_segment::ds);
+    generator->_as.pop(x86_segment::es);
+    generator->_as.mov(cpu_register::ah, 0x56);
+    generator->_as.intr(0x21);
+
+    return true;
+}
+
+bool
 zd::gen::zd4_builtins::ZPortu(zd4_generator        *generator,
                               const par::call_node &node)
 {

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -98,6 +98,15 @@ zd4_builtins::Klawisz(zd4_generator *generator, const par::call_node &node)
     return true;
 }
 
+bool
+zd4_builtins::Laduj(zd4_generator *generator, const par::call_node &node)
+{
+    REQUIRE(node.is_bare);
+
+    generator->_as.lodsb();
+    return true;
+}
+
 // Procedure $Losowa16
 static const uint8_t Losowa16_impl[]{
     0x1E,             // push ds

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -270,6 +270,11 @@ zd4_builtins::Pisz(zd4_generator *generator, const call_node &node)
         auto fileno = subscript->value->as<number_node>()->value;
 
         it++;
+        if (node.arguments.end() == it)
+        {
+            return Pisz(generator, fileno, "\r\n");
+        }
+
         if ((*it)->is<string_node>())
         {
             return Pisz(generator, fileno, (*it)->as<string_node>()->value);
@@ -309,6 +314,11 @@ zd4_builtins::PiszL(zd4_generator *generator, const call_node &node)
         auto fileno = subscript->value->as<number_node>()->value;
 
         it++;
+        if (node.arguments.end() == it)
+        {
+            return Pisz(generator, fileno, "\r\n");
+        }
+
         REQUIRE((*it)->is<string_node>());
         ustring value{(*it)->as<string_node>()->value};
         value.append('\r');

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -297,7 +297,15 @@ zd4_builtins::Pisz(zd4_generator *generator, const call_node &node)
         return Pisz(generator, (*it)->as<string_node>()->value);
     }
 
-    if (node.arguments.front()->is<object_node>())
+    if ((*it)->is<number_node>())
+    {
+        char buff[6];
+        std::snprintf(buff, sizeof(buff), "%u",
+                      (*it)->as<number_node>()->value);
+        return Pisz(generator, buff);
+    }
+
+    if ((*it)->is<object_node>())
     {
         return Pisz(generator, *(*it)->as<object_node>());
     }
@@ -341,6 +349,14 @@ zd4_builtins::PiszL(zd4_generator *generator, const call_node &node)
         value.append('\r');
         value.append('\n');
         return Pisz(generator, value);
+    }
+
+    if ((*it)->is<number_node>())
+    {
+        char buff[8];
+        std::snprintf(buff, sizeof(buff), "%u\r\n",
+                      (*it)->as<number_node>()->value);
+        return Pisz(generator, buff);
     }
 
     return false;

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -149,6 +149,15 @@ zd4_builtins::Losowa8(zd4_generator *generator, const call_node &node)
 }
 
 bool
+zd4_builtins::Nic(zd4_generator *generator, const par::call_node &node)
+{
+    REQUIRE(node.arguments.empty());
+
+    generator->_as.nop();
+    return true;
+}
+
+bool
 zd::gen::zd4_builtins::Otworz(zd4_generator        *generator,
                               const par::call_node &node)
 {

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -588,13 +588,11 @@ bool
 zd4_builtins::Tryb(zd4_generator *generator, const par::call_node &node)
 {
     REQUIRE(1 == node.arguments.size());
-    REQUIRE(node.arguments.front()->is<number_node>());
-
-    auto mode = node.arguments.front()->as<number_node>()->value;
-    REQUIRE((0 <= mode) && (UINT8_MAX >= mode));
 
     // INT 10,0 - Set Video Mode
-    generator->_as.mov(cpu_register::ax, mode);
+    REQUIRE(load_numeric_argument(generator, cpu_register::al,
+                                  *node.arguments.front()));
+    generator->_as.mov(cpu_register::ah, 0);
     generator->_as.intr(0x10);
 
     return true;

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -97,6 +97,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Losowa8(this, node);
     }
 
+    if (text::pl_streqi("Nic", node.callee))
+    {
+        return zd4_builtins::Nic(this, node);
+    }
+
     if (text::pl_streqi("Pisz", node.callee))
     {
         return zd4_builtins::Pisz(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -34,6 +34,13 @@ zd4_generator::process(const par::assignment_node &node)
             return true;
         }
 
+        if (node.source->is<object_node>())
+        {
+            _as.push(get_symbol(node.source->as<object_node>()->name));
+            _as.pop(get_symbol(node.target->as<object_node>()->name));
+            return true;
+        }
+
         if (node.source->is<register_node>())
         {
             auto src_reg = node.source->as<register_node>()->reg;

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -55,7 +55,41 @@ zd4_generator::process(const par::assignment_node &node)
         auto target = node.target->as<register_node>();
         auto dst = target->reg;
 
-        if (node.source->is<number_node>())
+        // Flag register
+        auto value = node.source->as<number_node>()->value;
+        if (cpu_register_flag == ((unsigned)dst & 0xFF00))
+        {
+            switch (dst)
+            {
+            case cpu_register::flag_c: {
+                if (value)
+                {
+                    return _as.stc();
+                }
+
+                return _as.clc();
+            }
+
+            case cpu_register::flag_d: {
+                if (value)
+                {
+                    return _as.std();
+                }
+
+                return _as.cld();
+            }
+
+            case cpu_register::flag_i: {
+                if (value)
+                {
+                    return _as.sti();
+                }
+
+                return _as.cli();
+            }
+            }
+        }
+        else if (node.source->is<number_node>())
         {
             _as.mov(dst, (uint16_t)node.source->as<number_node>()->value);
             return true;

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -34,6 +34,19 @@ zd4_generator::process(const par::assignment_node &node)
             return true;
         }
 
+        if (node.source->is<register_node>())
+        {
+            auto src_reg = node.source->as<register_node>()->reg;
+            _as.mov(cpu_register::di, dst);
+            if ((symbol_type::var_byte != dst.type) &&
+                (cpu_register_word != ((unsigned)src_reg & 0xFF00)))
+            {
+                _as.mov(mreg{cpu_register::di}, 0);
+            }
+            _as.mov(mreg{cpu_register::di}, src_reg);
+            return true;
+        }
+
         return false;
     }
 
@@ -400,7 +413,7 @@ zd4_generator::process(const par::operation_node &node)
     case operation::add: {
         if (node.left->is<object_node>() && node.right->is<number_node>())
         {
-            auto left_obj = node.left->as<object_node>();
+            auto  left_obj = node.left->as<object_node>();
             auto &left_sym = get_symbol(left_obj->name);
             auto  right_num = node.right->as<number_node>();
             if (1 == right_num->value)
@@ -425,7 +438,7 @@ zd4_generator::process(const par::operation_node &node)
 
         if (node.left->is<object_node>() && node.right->is<number_node>())
         {
-            auto left_obj = node.left->as<object_node>();
+            auto  left_obj = node.left->as<object_node>();
             auto &left_sym = get_symbol(left_obj->name);
             _as.cmp(left_sym, (uint16_t)node.right->as<number_node>()->value);
             return true;

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -426,11 +426,6 @@ zd4_generator::process(const par::operation_node &node)
         if (node.left->is<object_node>() && node.right->is<number_node>())
         {
             auto left_obj = node.left->as<object_node>();
-            if (object_type::word != left_obj->type)
-            {
-                return false;
-            }
-
             auto &left_sym = get_symbol(left_obj->name);
             _as.cmp(left_sym, (uint16_t)node.right->as<number_node>()->value);
             return true;

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -502,6 +502,18 @@ zd4_generator::process(const par::operation_node &node)
             return true;
         }
 
+        if (node.left->is<object_node>() && node.right->is<object_node>())
+        {
+            auto  left_obj = node.left->as<object_node>();
+            auto  right_obj = node.left->as<object_node>();
+            auto &left_sym = get_symbol(left_obj->name);
+            auto &right_sym = get_symbol(right_obj->name);
+            _as.mov(cpu_register::bx, left_sym);
+            _as.mov(cpu_register::bx, mreg{cpu_register::bx});
+            _as.cmp(cpu_register::bx, right_sym);
+            return true;
+        }
+
         return false;
     }
 

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -95,6 +95,11 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::Klawisz(this, node);
     }
 
+    if (text::pl_streqai("Ładuj", node.callee))
+    {
+        return zd4_builtins::Laduj(this, node);
+    }
+
     if (text::pl_streqi("Losowa16", node.callee))
     {
         return zd4_builtins::Losowa16(this, node);

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -416,6 +416,20 @@ zd4_generator::process(const par::operation_node &node)
     switch (node.op)
     {
     case operation::add: {
+        if (node.left->is<register_node>() && node.right->is<number_node>())
+        {
+            auto left_reg = node.left->as<register_node>();
+            auto right_num = node.right->as<number_node>();
+            if (1 == right_num->value)
+            {
+                _as.inc(left_reg->reg);
+                return true;
+            }
+
+            _as.add(left_reg->reg, right_num->value);
+            return true;
+        }
+
         if (node.left->is<object_node>() && node.right->is<number_node>())
         {
             auto  left_obj = node.left->as<object_node>();

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -190,14 +190,19 @@ zd4_generator::process(const par::call_node &node)
         return zd4_builtins::UsunPlik(this, node);
     }
 
+    if (text::pl_streqai("Zamknij", node.callee))
+    {
+        return zd4_builtins::Zamknij(this, node);
+    }
+
     if (text::pl_streqai("ZmieńKatalog", node.callee))
     {
         return zd4_builtins::ZmienKatalog(this, node);
     }
 
-    if (text::pl_streqai("Zamknij", node.callee))
+    if (text::pl_streqai("ZmieńNazwę", node.callee))
     {
-        return zd4_builtins::Zamknij(this, node);
+        return zd4_builtins::ZmienNazwe(this, node);
     }
 
     if (text::pl_streqai("ZPortu", node.callee))


### PR DESCRIPTION
Przykłady:
- DEMO: usuń konflikt nazw zmiennej i procedury
- SAVER: dostosuj kod źródłowy do skompilowanego przykładu
- dodaj przykłady użycia bibliotek DZWIEK2, KLAWIAT i MYSZ

ZD4:
- obsłuż zmienne tekstowe w operacjach plikowych, bezargumentowe `Pisz` i `PiszL` z plikiem, `Nic` oraz popraw wywołanie `INT 21,3E` (zgodność: DOWCIPY)
- obsłuż `Pisz` i `PiszL` z liczbą, `CMP r/m8, imm8`, `Pozycja` i `PiszZnak` ze zmiennymi i rejestrami oraz `Pisz` i `PiszL` ze składanymi ciągami (zgodność: DOGIER, GRA)
- obsłuż przypisanie rejestru do zmiennej oraz `ZmieńNazwę` (zgodność: ZC)
- obsłuż `Pisz8` ze zmienną tekstową (zgodność: ASCII)
- obsłuż `Tryb` i `Pisz` do pliku ze zmienną (zgodność: DEMO)
- obsłuż bezargumentowe `Pisz8` (zgodność: LOSOWE)
- obsłuż `Zwiększ` rejestru o liczbę, `Ładuj` oraz operacje na flagach (zgodność: PARAMETR)
- obsłuż porównanie dwóch zmiennych, przypisanie zmiennej do zmiennej oraz `ZmieńNazwę` z dwoma literałami tekstowymi (zgodność: PLIKI1, PLIKI2)