### PR TITLE
Buduj dla macOS z użyciem Apple Clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,16 @@ jobs:
     strategy:
       matrix:
         platform:
-          - name: Linux
-            target: linux
-            os: ubuntu-latest
           - name: DOS (IA16)
             target: dos-ia16
             os: ubuntu-latest
             flags: -DCMAKE_TOOLCHAIN_FILE=ext/nicetia16/cmake/DOS-GCC-IA16.cmake
+          - name: Linux
+            target: linux
+            os: ubuntu-latest
+          - name: macOS
+            target: macos
+            os: macos-latest
           - name: Windows (x64)
             target: windows-x64
             os: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ if(MSVC)
     add_compile_options(/utf-8)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wno-switch)
+endif()
+
 if(DOS)
     add_compile_options(-march=i8088)
     add_compile_options(-mcmodel=small)

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_executable(lek05-03)
+set_property(TARGET lek05-03 PROPERTY CXX_STANDARD 14)
 target_link_libraries(lek05-03 zdstd)
 target_sources(lek05-03 PRIVATE KURS/SAMPLE/LEKCJA05/lek05-03.cpp)

--- a/tools/mconv.py
+++ b/tools/mconv.py
@@ -40,7 +40,7 @@ def get_messages(input: TextIOWrapper) -> Generator[tuple[int, int, str], None, 
             message_text = str()
             continue
 
-        if re.match("^\w+=", line):
+        if re.match(r"^\w+=", line):
             key, value = get_assignment(line)
             if key == "LanguageNames":
                 lang_name, details = get_assignment(value)

--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -89,7 +89,10 @@ class error
     }
 
   public:
-    template <typename Torigin, typename Traits = error_origin_traits<Torigin>>
+    template <typename Torigin,
+              typename Traits = error_origin_traits<Torigin>,
+              typename... Args,
+              typename std::enable_if<sizeof...(Args) == 0, int>::type = 0>
     error(const Torigin &origin, typename Traits::ordinal_type code)
         : _origin{static_cast<uint8_t>(Traits::origin_tag)},
           _ordinal{static_cast<uint8_t>(code)}, _file{Traits::path(origin)},
@@ -100,7 +103,8 @@ class error
 
     template <typename Torigin,
               typename Traits = error_origin_traits<Torigin>,
-              typename... Args>
+              typename... Args,
+              typename std::enable_if<sizeof...(Args) != 0, int>::type = 0>
     error(const Torigin                &origin,
           typename Traits::ordinal_type code,
           Args... args)

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -87,6 +87,8 @@ struct node
     virtual bool
     generate(gen::generator *generator) = 0;
 
+    virtual ~node() = default;
+
     template <typename T>
     inline T *
     as()


### PR DESCRIPTION
Ogólne:
- buduj dla macOS

Narzędzia:
- popraw wyrażenie regularne

Przykłady:
- ustaw standard języka C++14

ZDC:
- dodaj wirtualny destruktor klasy `node`
- ignoruj brakujące wartości w `switch`, budując z użyciem Clang
- usuń niejednoznaczność wywołania konstruktora klasy `error`
