### PR TITLE
Zgłaszaj szczegóły błędów generatora

### DIFF
--- a/tools/mconv.py
+++ b/tools/mconv.py
@@ -36,7 +36,7 @@ def get_messages(input: TextIOWrapper) -> Generator[tuple[int, int, str], None, 
             continue
 
         if line.rstrip() == ".":
-            yield message_id, message_language, message_text.rstrip()
+            yield message_id, message_language, message_text.rstrip("\n")
             message_text = str()
             continue
 

--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -89,6 +89,17 @@ class error
     }
 
   public:
+    error()
+        : _origin{0}, _ordinal{0}, _file{}, _line{0}, _column{0}, _argc{0},
+          _argv{nullptr}
+    {
+    }
+
+    operator bool() const
+    {
+        return (0 == _origin) && (0 == _ordinal);
+    }
+
     template <typename Torigin,
               typename Traits = error_origin_traits<Torigin>,
               typename... Args,

--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -197,6 +197,7 @@ enum class error_origin : uint8_t
     stream = 1,
     lexer = 2,
     parser = 3,
+    generator = 4,
 };
 
 template <typename T> using result = tl::expected<T, error>;

--- a/zdc/include/zd/gen/generator.hpp
+++ b/zdc/include/zd/gen/generator.hpp
@@ -94,6 +94,7 @@ enum class generator_error
     invalid_argument = 0x08,     // invalid argument
     assembler_error = 0x80,
     not_a_builtin = 0x81,
+    undefined_name = 0x82,
 };
 
 } // namespace gen

--- a/zdc/include/zd/gen/generator.hpp
+++ b/zdc/include/zd/gen/generator.hpp
@@ -91,7 +91,9 @@ enum class generator_error
     unexpected_arguments = 0x05, // cannot invoke X with arguments
     symbol_redefinition = 0x06,  // cannot redefine X
     string_too_long = 0x07,      // string constant is too long
+    invalid_argument = 0x08,     // invalid argument
     assembler_error = 0x80,
+    not_a_builtin = 0x81,
 };
 
 } // namespace gen

--- a/zdc/include/zd/gen/generator.hpp
+++ b/zdc/include/zd/gen/generator.hpp
@@ -33,52 +33,52 @@ namespace gen
 // Output generator interface
 struct generator
 {
-    virtual bool
+    virtual error
     process(const par::assignment_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::call_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::condition_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::declaration_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::end_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::emit_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::include_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::jump_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::label_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::number_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::object_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::operation_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::procedure_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::register_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::string_node &node) = 0;
 
-    virtual bool
+    virtual error
     process(const par::subscript_node &node) = 0;
 };
 

--- a/zdc/include/zd/gen/generator.hpp
+++ b/zdc/include/zd/gen/generator.hpp
@@ -82,6 +82,11 @@ struct generator
     process(const par::subscript_node &node) = 0;
 };
 
+enum class generator_error
+{
+    error, // TODO: define error codes
+};
+
 } // namespace gen
 
 } // namespace zd

--- a/zdc/include/zd/gen/generator.hpp
+++ b/zdc/include/zd/gen/generator.hpp
@@ -84,7 +84,14 @@ struct generator
 
 enum class generator_error
 {
-    error, // TODO: define error codes
+    unexpected_node = 0x01,      // unexpected X
+    invalid_operands = 0x02,     // cannot X Y and Z
+    invalid_assignment = 0x03,   // cannot assign X to Y
+    nonconst_assignment = 0x04,  // cannot assign variable at declaration
+    unexpected_arguments = 0x05, // cannot invoke X with arguments
+    symbol_redefinition = 0x06,  // cannot redefine X
+    string_too_long = 0x07,      // string constant is too long
+    assembler_error = 0x80,
 };
 
 } // namespace gen

--- a/zdc/include/zd/gen/text_generator.hpp
+++ b/zdc/include/zd/gen/text_generator.hpp
@@ -19,52 +19,52 @@ class text_generator : public generator
     {
     }
 
-    bool
+    error
     process(const par::assignment_node &node) override;
 
-    bool
+    error
     process(const par::call_node &node) override;
 
-    bool
+    error
     process(const par::condition_node &node) override;
 
-    bool
+    error
     process(const par::declaration_node &node) override;
 
-    bool
+    error
     process(const par::end_node &node) override;
 
-    bool
+    error
     process(const par::emit_node &node) override;
 
-    bool
+    error
     process(const par::include_node &node) override;
 
-    bool
+    error
     process(const par::jump_node &node) override;
 
-    bool
+    error
     process(const par::label_node &node) override;
 
-    bool
+    error
     process(const par::number_node &node) override;
 
-    bool
+    error
     process(const par::object_node &node) override;
 
-    bool
+    error
     process(const par::operation_node &node) override;
 
-    bool
+    error
     process(const par::procedure_node &node) override;
 
-    bool
+    error
     process(const par::register_node &node) override;
 
-    bool
+    error
     process(const par::string_node &node) override;
 
-    bool
+    error
     process(const par::subscript_node &node) override;
 };
 

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -36,20 +36,24 @@ using extract_args = typename member_function_traits<T>::arg_types;
 
 struct zd4_byte
 {
+    const par::node *node;
+
     const symbol     *sym;
     par::cpu_register reg;
     uint8_t           val;
 
-    zd4_byte(symbol *sym_) : sym{sym_}, reg{par::cpu_register::invalid}, val{}
+    zd4_byte(symbol *sym_, const par::node *node_ = nullptr)
+        : sym{sym_}, reg{par::cpu_register::invalid}, val{}, node{node_}
     {
     }
 
-    zd4_byte(par::cpu_register reg_) : sym{nullptr}, reg{reg_}, val{}
+    zd4_byte(par::cpu_register reg_, const par::node *node_ = nullptr)
+        : sym{nullptr}, reg{reg_}, val{}, node{node_}
     {
     }
 
-    zd4_byte(uint8_t val_)
-        : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}
+    zd4_byte(uint8_t val_, const par::node *node_ = nullptr)
+        : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}, node{node_}
     {
     }
 
@@ -59,9 +63,12 @@ struct zd4_byte
 
 struct zd4_file
 {
+    const par::node *node;
+
     uint16_t val;
 
-    zd4_file(uint16_t val_) : val{val_}
+    zd4_file(uint16_t val_, const par::node *node_ = nullptr)
+        : val{val_}, node{node_}
     {
     }
 
@@ -71,14 +78,18 @@ struct zd4_file
 
 struct zd4_text
 {
+    const par::node *node;
+
     const symbol  *sym;
     const ustring *val;
 
-    zd4_text(const symbol *sym_) : sym{sym_}, val{nullptr}
+    zd4_text(const symbol *sym_, const par::node *node_ = nullptr)
+        : sym{sym_}, val{nullptr}, node{node_}
     {
     }
 
-    zd4_text(const ustring *val_) : sym{nullptr}, val{val_}
+    zd4_text(const ustring *val_, const par::node *node_ = nullptr)
+        : sym{nullptr}, val{val_}, node{node_}
     {
     }
 
@@ -93,21 +104,24 @@ struct zd4_text
 
 struct zd4_word
 {
+    const par::node *node;
+
     const symbol     *sym;
     par::cpu_register reg;
     uint16_t          val;
 
-    zd4_word(const symbol *sym_)
-        : sym{sym_}, reg{par::cpu_register::invalid}, val{}
+    zd4_word(const symbol *sym_, const par::node *node_ = nullptr)
+        : sym{sym_}, reg{par::cpu_register::invalid}, val{}, node{node_}
     {
     }
 
-    zd4_word(par::cpu_register reg_) : sym{nullptr}, reg{reg_}, val{}
+    zd4_word(par::cpu_register reg_, const par::node *node_ = nullptr)
+        : sym{nullptr}, reg{reg_}, val{}, node{node_}
     {
     }
 
-    zd4_word(uint16_t val_)
-        : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}
+    zd4_word(uint16_t val_, const par::node *node_ = nullptr)
+        : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}, node{node_}
     {
     }
 
@@ -117,198 +131,198 @@ struct zd4_word
 
 class zd4_builtins
 {
-    bool
+    error
     Czekaj_w(const zd4_word &czas);
 
-    bool
+    error
     Czysc()
     {
         return Czysc_b(7);
     }
 
-    bool
+    error
     Czysc_b(const zd4_byte &atrybut);
 
-    bool
+    error
     Czytaj_T(zd4_text &atrybut);
 
-    bool
+    error
     DoPortu();
 
-    bool
+    error
     Klawisz();
 
-    bool
+    error
     Laduj();
 
-    bool
+    error
     Losowa16();
 
-    bool
+    error
     Losowa8();
 
-    bool
+    error
     Nic();
 
-    bool
+    error
     Otworz_ft(const zd4_file &plik, const zd4_text &nazwa)
     {
         return Otworz_ftb(plik, nazwa, 2);
     }
 
-    bool
+    error
     Otworz_ftb(const zd4_file &plik,
                const zd4_text &nazwa,
                const zd4_byte &tryb);
 
-    bool
+    error
     Pisz()
     {
         ustring str{"\r\n"};
         return Pisz_t(&str);
     }
 
-    bool
+    error
     Pisz_t(const zd4_text &tekst);
 
-    bool
+    error
     Pisz_tt(const zd4_text &tekst1, const zd4_text &tekst2);
 
-    bool
+    error
     Pisz_f(const zd4_file &plik)
     {
         ustring str{"\r\n"};
         return Pisz_ft(plik, &str);
     }
 
-    bool
+    error
     Pisz_ft(const zd4_file &plik, const zd4_text &tekst);
 
-    bool
+    error
     Pisz_ftt(const zd4_file &plik,
              const zd4_text &tekst1,
              const zd4_text &tekst2);
 
-    bool
+    error
     Pisz_w(const zd4_word &liczba);
 
-    bool
+    error
     Pisz_fw(const zd4_file &plik, const zd4_word &liczba);
 
-    bool
+    error
     PiszL()
     {
         ustring str{""};
         return PiszL_t(&str);
     }
 
-    bool
+    error
     PiszL_t(const zd4_text &tekst);
 
-    bool
+    error
     PiszL_tt(const zd4_text &tekst1, const zd4_text &tekst2);
 
-    bool
+    error
     PiszL_f(const zd4_file &plik)
     {
         ustring str{""};
         return PiszL_ft(plik, &str);
     }
 
-    bool
+    error
     PiszL_ft(const zd4_file &plik, const zd4_text &tekst);
 
-    bool
+    error
     PiszL_ftt(const zd4_file &plik,
               const zd4_text &tekst1,
               const zd4_text &tekst2);
 
-    bool
+    error
     PiszL_w(const zd4_word &liczba);
 
-    bool
+    error
     PiszL_fw(const zd4_file &plik, const zd4_word &liczba);
 
-    bool
+    error
     Pisz8()
     {
         return Pisz8_b(par::cpu_register::al);
     }
 
-    bool
+    error
     Pisz8_b(const zd4_byte &liczba);
 
-    bool
+    error
     Pisz8_t(const zd4_text &tekst);
 
-    bool
+    error
     PiszZnak_b(const zd4_byte &znak)
     {
         return PiszZnak_bb(znak, 7);
     }
 
-    bool
+    error
     PiszZnak_bb(const zd4_byte &znak, const zd4_byte &atrybut)
     {
         return PiszZnak_bbw(znak, atrybut, 1);
     }
 
-    bool
+    error
     PiszZnak_bbw(const zd4_byte &znak,
                  const zd4_byte &atrybut,
                  const zd4_word &powtorzenia);
 
-    bool
+    error
     Pozycja_bb(const zd4_byte &kolumna, const zd4_byte &wiersz);
 
-    bool
+    error
     PokazMysz();
 
-    bool
+    error
     Przerwanie_b(const zd4_byte &numer);
 
-    bool
+    error
     Punkt_wwb(const zd4_word &kolumna,
               const zd4_word &wiersz,
               const zd4_byte &kolor);
 
-    bool
+    error
     StanPrzyciskow();
 
-    bool
+    error
     StanPrzyciskow_t(const zd4_text &tekst);
 
-    bool
+    error
     Tryb_b(const zd4_byte &tryb);
 
-    bool
+    error
     TworzKatalog_t(const zd4_text &tekst);
 
-    bool
+    error
     TworzPlik_t(const zd4_text &tekst);
 
-    bool
+    error
     UkryjMysz();
 
-    bool
+    error
     UsunKatalog_t(const zd4_text &tekst);
 
-    bool
+    error
     UsunPlik_t(const zd4_text &tekst);
 
-    bool
+    error
     Zamknij_f(const zd4_file &plik);
 
-    bool
+    error
     ZmienKatalog_t(const zd4_text &tekst);
 
-    bool
+    error
     ZmienNazwe_tt(const zd4_text &stara, const zd4_text &nowa);
 
-    bool
+    error
     ZmienNazwe_t(const zd4_text &stara_nowa);
 
-    bool
+    error
     ZPortu();
 
     symbol *
@@ -318,12 +332,15 @@ class zd4_builtins
     x86_assembler &as;
     zd4_generator &gen;
 
-    zd4_builtins(zd4_generator &gen_) : as{gen_._as}, gen{gen_}
+    zd4_builtins(zd4_generator &gen_) : as{gen_._as}, gen{gen_}, _node{nullptr}
     {
     }
 
-    bool
-    dispatch(const ustring &name, const par::node_list &args);
+    error
+    dispatch(const par::call_node &node);
+
+  private:
+    const par::call_node *_node;
 };
 
 } // namespace gen

--- a/zdc/include/zd/gen/zd4_generator.hpp
+++ b/zdc/include/zd/gen/zd4_generator.hpp
@@ -177,6 +177,9 @@ class zd4_generator : public generator, public zd4_reference_resolver
     make_string_too_long(const par::string_node &node);
 
     error
+    make_invalid_argument(const par::node &node);
+
+    error
     make_assembler_error(const par::node &node);
 
     class nesting_guard

--- a/zdc/include/zd/gen/zd4_generator.hpp
+++ b/zdc/include/zd/gen/zd4_generator.hpp
@@ -85,6 +85,7 @@ class zd4_generator : public generator, public zd4_reference_resolver
     bool
     process(const par::include_node &node) override
     {
+        assert(false && "include node passed to the generator");
         return false;
     }
 
@@ -97,12 +98,14 @@ class zd4_generator : public generator, public zd4_reference_resolver
     bool
     process(const par::number_node &node) override
     {
+        set_position(node);
         return false;
     }
 
     bool
     process(const par::object_node &node) override
     {
+        set_position(node);
         return false;
     }
 
@@ -115,18 +118,21 @@ class zd4_generator : public generator, public zd4_reference_resolver
     bool
     process(const par::register_node &node) override
     {
+        set_position(node);
         return false;
     }
 
     bool
     process(const par::string_node &node) override
     {
+        set_position(node);
         return false;
     }
 
     bool
     process(const par::subscript_node &node) override
     {
+        set_position(node);
         return false;
     }
 

--- a/zdc/include/zd/gen/zd4_generator.hpp
+++ b/zdc/include/zd/gen/zd4_generator.hpp
@@ -64,76 +64,71 @@ class zd4_generator : public generator, public zd4_reference_resolver
         return _column;
     }
 
-    bool
+    error
     process(const par::assignment_node &node) override;
 
-    bool
+    error
     process(const par::call_node &node) override;
 
-    bool
+    error
     process(const par::condition_node &node) override;
 
-    bool
+    error
     process(const par::declaration_node &node) override;
 
-    bool
+    error
     process(const par::end_node &node) override;
 
-    bool
+    error
     process(const par::emit_node &node) override;
 
-    bool
+    error
     process(const par::include_node &node) override
     {
         assert(false && "include node passed to the generator");
-        return false;
+        return {};
     }
 
-    bool
+    error
     process(const par::jump_node &node) override;
 
-    bool
+    error
     process(const par::label_node &node) override;
 
-    bool
+    error
     process(const par::number_node &node) override
     {
-        set_position(node);
-        return false;
+        return make_error(node);
     }
 
-    bool
+    error
     process(const par::object_node &node) override
     {
-        set_position(node);
-        return false;
+        return make_error(node);
     }
 
-    bool
+    error
     process(const par::operation_node &node) override;
 
-    bool
+    error
     process(const par::procedure_node &node) override;
 
-    bool
+    error
     process(const par::register_node &node) override
     {
-        set_position(node);
-        return false;
+        return make_error(node);
     }
 
-    bool
+    error
     process(const par::string_node &node) override
     {
-        set_position(node);
-        return false;
+        return make_error(node);
     }
 
-    bool
+    error
     process(const par::subscript_node &node) override
     {
-        set_position(node);
-        return false;
+        return make_error(node);
     }
 
     void
@@ -159,6 +154,9 @@ class zd4_generator : public generator, public zd4_reference_resolver
                symbol_type       type,
                zd4_known_section section,
                unsigned          address);
+
+    error
+    make_error(const par::node &node);
 
     class nesting_guard
     {

--- a/zdc/include/zd/gen/zd4_generator.hpp
+++ b/zdc/include/zd/gen/zd4_generator.hpp
@@ -98,13 +98,13 @@ class zd4_generator : public generator, public zd4_reference_resolver
     error
     process(const par::number_node &node) override
     {
-        return make_error(node);
+        return make_unexpected_node(node);
     }
 
     error
     process(const par::object_node &node) override
     {
-        return make_error(node);
+        return make_unexpected_node(node);
     }
 
     error
@@ -116,19 +116,19 @@ class zd4_generator : public generator, public zd4_reference_resolver
     error
     process(const par::register_node &node) override
     {
-        return make_error(node);
+        return make_unexpected_node(node);
     }
 
     error
     process(const par::string_node &node) override
     {
-        return make_error(node);
+        return make_unexpected_node(node);
     }
 
     error
     process(const par::subscript_node &node) override
     {
-        return make_error(node);
+        return make_unexpected_node(node);
     }
 
     void
@@ -156,7 +156,28 @@ class zd4_generator : public generator, public zd4_reference_resolver
                unsigned          address);
 
     error
-    make_error(const par::node &node);
+    make_unexpected_node(const par::node &node);
+
+    error
+    make_invalid_operands(const par::operation_node &node);
+
+    error
+    make_invalid_assignment(const par::assignment_node &node);
+
+    error
+    make_nonconst_assignment(const par::assignment_node &node);
+
+    error
+    make_unexpected_arguments(const par::node &node);
+
+    error
+    make_symbol_redefinition(const par::node &node);
+
+    error
+    make_string_too_long(const par::string_node &node);
+
+    error
+    make_assembler_error(const par::node &node);
 
     class nesting_guard
     {

--- a/zdc/include/zd/gen/zd4_generator.hpp
+++ b/zdc/include/zd/gen/zd4_generator.hpp
@@ -131,13 +131,11 @@ class zd4_generator : public generator, public zd4_reference_resolver
         return make_unexpected_node(node);
     }
 
-    void
+    result<void>
     link(std::FILE *output);
 
-    bool
-    get_symbol_address(unsigned  index,
-                       unsigned &section,
-                       unsigned &address) const override;
+    result<std::pair<unsigned, unsigned>>
+    get_symbol_address(unsigned index) override;
 
     symbol &
     get_symbol(const ustring &name);
@@ -181,6 +179,9 @@ class zd4_generator : public generator, public zd4_reference_resolver
 
     error
     make_assembler_error(const par::node &node);
+
+    error
+    make_undefined(const ustring &name);
 
     class nesting_guard
     {

--- a/zdc/include/zd/gen/zd4_generator.hpp
+++ b/zdc/include/zd/gen/zd4_generator.hpp
@@ -28,14 +28,40 @@ class zd4_generator : public generator, public zd4_reference_resolver
 
     x86_assembler _as;
 
+    ustring  _path;
+    unsigned _line;
+    unsigned _column;
+
   public:
     zd4_generator()
         : _codes{}, _data{zd4_section_data}, _udat{zd4_section_udat, false},
-          _symbols{}, _symbol_num{0}, _as{_data}
+          _symbols{}, _symbol_num{0}, _as{_data}, _path{}, _line{1}, _column{1}
     {
         _codes.emplace_back(zd4_section_code);
         _curr_code = _codes.begin();
         _as.bind_code(*_curr_code);
+    }
+
+    static const auto error_origin_tag = error_origin::generator;
+
+    using error_code = generator_error;
+
+    const ustring &
+    get_path() const
+    {
+        return _path;
+    }
+
+    unsigned
+    get_line() const
+    {
+        return _line;
+    }
+
+    unsigned
+    get_column() const
+    {
+        return _column;
     }
 
     bool
@@ -118,6 +144,9 @@ class zd4_generator : public generator, public zd4_reference_resolver
   private:
     static ustring
     get_cname(const ustring &name);
+
+    void
+    set_position(const par::node &node);
 
     bool
     set_symbol(const ustring    &name,

--- a/zdc/include/zd/gen/zd4_section.hpp
+++ b/zdc/include/zd/gen/zd4_section.hpp
@@ -35,10 +35,8 @@ enum zd4_known_section
 
 struct zd4_reference_resolver
 {
-    virtual bool
-    get_symbol_address(unsigned  index,
-                       unsigned &section,
-                       unsigned &address) const = 0;
+    virtual result<std::pair<unsigned, unsigned>>
+    get_symbol_address(unsigned index) = 0;
 };
 
 class zd4_section
@@ -85,10 +83,10 @@ class zd4_section
     unsigned
     reserve(unsigned size);
 
-    bool
-    relocate(std::FILE                    *output,
-             const uint16_t               *bases,
-             const zd4_reference_resolver *resolver);
+    result<void>
+    relocate(std::FILE              *output,
+             const uint16_t         *bases,
+             zd4_reference_resolver *resolver);
 };
 
 } // namespace gen

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -382,4 +382,7 @@ struct subscript_node : public node
 
 } // namespace par
 
+const char *
+to_cstr(par::operation op);
+
 } // namespace zd

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -21,6 +21,7 @@ enum class object_type
     text,
     byte,
     word,
+    procedure,
 };
 
 enum class condition
@@ -158,6 +159,10 @@ struct call_node : public node
     const ustring   callee;
     const node_list arguments;
     const bool      is_bare;
+
+    call_node() : node{}, callee{}, arguments{}, is_bare{false}
+    {
+    }
 
     call_node(const position &pos,
               const ustring  &callee_,

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -114,6 +114,17 @@ struct node
     }
 
     template <typename T>
+    inline const T *
+    as() const
+    {
+#ifdef __ia16__
+        return reinterpret_cast<const T *>(this);
+#else
+        return dynamic_cast<const T *>(this);
+#endif
+    }
+
+    template <typename T>
     inline bool
     is() const
     {
@@ -181,6 +192,10 @@ struct condition_node : public node
     const condition   cond;
     const unique_node action;
 
+    condition_node() : cond{condition::equal}, action{}
+    {
+    }
+
     condition_node(const position &pos, condition cond_, unique_node action_)
         : node{pos}, cond{cond_}, action{std::move(action_)}
     {
@@ -194,6 +209,10 @@ struct declaration_node : public node
     const unique_node target;
     const bool        is_const;
 
+    declaration_node() : target{}, is_const{false}
+    {
+    }
+
     declaration_node(const position &pos, unique_node target_, bool is_const_)
         : node{pos}, target{std::move(target_)}, is_const{is_const_}
     {
@@ -205,6 +224,8 @@ struct declaration_node : public node
 struct emit_node : public node
 {
     const std::vector<uint8_t> bytes;
+
+    emit_node() = default;
 
     emit_node(const position &pos, std::vector<uint8_t> bytes_)
         : node{pos}, bytes{std::move(bytes_)}
@@ -316,6 +337,10 @@ struct operation_node : public node
     const unique_node left;
     const unique_node right;
 
+    operation_node() : op{operation::add}, left{}, right{}
+    {
+    }
+
     operation_node(const position &pos,
                    operation       op_,
                    unique_node     left_,
@@ -331,6 +356,8 @@ struct procedure_node : public node
 {
     const ustring   name;
     const node_list body;
+
+    procedure_node() = default;
 
     procedure_node(const position &pos, const ustring &name_, node_list body_)
         : node{pos}, name{name_}, body{std::move(body_)}
@@ -386,6 +413,9 @@ struct subscript_node : public node
 #undef IMPLEMENT_GENERATOR_ACCESS
 
 } // namespace par
+
+const char *
+to_cstr(const par::node &node);
 
 const char *
 to_cstr(par::operation op);

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -114,14 +114,14 @@ struct node
 
     template <typename T>
     inline bool
-    is()
+    is() const
     {
 #ifdef __ia16__
         T specimen{};
-        return *reinterpret_cast<void ***>(&specimen) ==
-               *reinterpret_cast<void ***>(this);
+        return *reinterpret_cast<void **const *>(&specimen) ==
+               *reinterpret_cast<void **const *>(this);
 #else
-        return !!dynamic_cast<T *>(this);
+        return !!dynamic_cast<const T *>(this);
 #endif
     }
 

--- a/zdc/include/zd/par/node.hpp
+++ b/zdc/include/zd/par/node.hpp
@@ -85,7 +85,7 @@ struct position
 };
 
 #define IMPLEMENT_GENERATOR_ACCESS                                             \
-    virtual bool generate(gen::generator *generator) override                  \
+    virtual error generate(gen::generator *generator) override                 \
     {                                                                          \
         return generator->process(*this);                                      \
     }
@@ -96,7 +96,7 @@ struct node
     const unsigned code_line;
     const unsigned code_column;
 
-    virtual bool
+    virtual error
     generate(gen::generator *generator) = 0;
 
     virtual ~node() = default;

--- a/zdc/include/zd/par/parser.hpp
+++ b/zdc/include/zd/par/parser.hpp
@@ -55,56 +55,65 @@ class parser
     };
 
   private:
+    position
+    track();
+
     result<unique_node>
-    handle_assignment(lex::token_type ttype,
+    handle_assignment(const position &pos,
+                      lex::token_type ttype,
                       cpu_register    reg = cpu_register::invalid,
                       ustring         name = ustring{});
 
     result<unique_node>
-    handle_call(const ustring &callee, bool enclosed = false);
+    handle_call(const position &pos,
+                const ustring  &callee,
+                bool            enclosed = false);
 
     result<unique_node>
-    handle_condition(lex::token_type   ttype,
+    handle_condition(const position   &pos,
+                     lex::token_type   ttype,
                      const lex::token &head = lex::token{});
 
     result<unique_node>
-    handle_declaration(bool is_const);
+    handle_declaration(const position &pos, bool is_const);
 
     result<unique_node>
-    handle_directive(const ustring &directive);
+    handle_directive(const position &pos, const ustring &directive);
 
     result<unique_node>
-    handle_end();
+    handle_end(const position &pos);
 
     result<unique_node>
-    handle_jump();
+    handle_jump(const position &pos);
 
     result<unique_node>
-    handle_label();
+    handle_label(const position &pos);
 
     result<unique_node>
-    handle_number(int number);
+    handle_number(const position &pos, int number);
 
     result<unique_node>
-    handle_object(lex::token_type ttype, ustring name = ustring{});
+    handle_object(const position &pos,
+                  lex::token_type ttype,
+                  ustring         name = ustring{});
 
     result<unique_node>
-    handle_operation(lex::token_type ttype);
+    handle_operation(const position &pos, lex::token_type ttype);
 
     result<unique_node>
-    handle_procedure();
+    handle_procedure(const position &pos);
 
     result<unique_node>
-    handle_register(cpu_register reg);
+    handle_register(const position &pos, cpu_register reg);
 
     result<unique_node>
-    handle_string(const ustring &str, int spaces = 0);
+    handle_string(const position &pos, const ustring &str, int spaces = 0);
 
     result<unique_node>
-    handle_subscript();
+    handle_subscript(const position &pos);
 
     result<unique_node>
-    handle_value();
+    handle_value(const position &pos);
 
     tl::unexpected<error>
     make_error(error_code code)

--- a/zdc/src/CMakeLists.txt
+++ b/zdc/src/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_subdirectory(zd)
 
 target_sources(zdc PRIVATE zdc.cpp)
+
+if(DOS)
+    target_sources(zdc PRIVATE rstd.c)
+endif()

--- a/zdc/src/rstd.c
+++ b/zdc/src/rstd.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+uint64_t
+__udivdi3(uint64_t a, uint64_t b)
+{
+    return 0;
+}
+
+uint64_t
+__umoddi3(uint64_t a, uint64_t b)
+{
+    return 0;
+}

--- a/zdc/src/zd/gen/text_generator.cpp
+++ b/zdc/src/zd/gen/text_generator.cpp
@@ -7,7 +7,7 @@ using namespace zd;
 using namespace zd::gen;
 using namespace zd::par;
 
-bool
+error
 text_generator::process(const assignment_node &node)
 {
     std::fputs("<assignment ", _out);
@@ -15,10 +15,10 @@ text_generator::process(const assignment_node &node)
     std::fputc(' ', _out);
     node.source->generate(this);
     std::fputc('>', _out);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const call_node &node)
 {
     std::fputs("<call ", _out);
@@ -36,10 +36,10 @@ text_generator::process(const call_node &node)
     }
 
     std::fputc('>', _out);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const operation_node &node)
 {
     std::fputs("<operation ", _out);
@@ -63,10 +63,10 @@ text_generator::process(const operation_node &node)
     std::fputc(' ', _out);
     node.right->generate(this);
     std::fputc('>', _out);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const condition_node &node)
 {
     std::fputs("<condition ", _out);
@@ -101,10 +101,10 @@ text_generator::process(const condition_node &node)
     node.action->generate(this);
 
     std::fputc('>', _out);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const declaration_node &node)
 {
     std::fputs("<declaration ", _out);
@@ -116,9 +116,9 @@ text_generator::process(const declaration_node &node)
 
     node.target->generate(this);
     std::fputc('>', _out);
-    return true;
+    return {};
 }
-bool
+error
 text_generator::process(const emit_node &node)
 {
     std::fputs("<emit", _out);
@@ -129,59 +129,59 @@ text_generator::process(const emit_node &node)
     }
 
     std::fputc('>', _out);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const end_node &node)
 {
     if (node.name.empty())
     {
         std::fputs("<end>", _out);
-        return true;
+        return {};
     }
 
     std::fprintf(_out, "<end %s>", node.name.data());
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const include_node &node)
 {
     if (node.is_binary)
     {
         std::fprintf(_out, "<include binary %s>", node.name.data());
-        return true;
+        return {};
     }
 
     std::fprintf(_out, "<include %s>", node.name.data());
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const jump_node &node)
 {
     std::fputs("<jump ", _out);
     node.target->generate(this);
     std::fputc('>', _out);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const label_node &node)
 {
     std::fprintf(_out, "<label %s>", node.name.data());
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const number_node &node)
 {
     std::fprintf(_out, "<number %d>", node.value);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const object_node &node)
 {
     std::fprintf(_out, "<object %s:", node.name.data());
@@ -202,10 +202,10 @@ text_generator::process(const object_node &node)
     }
 
     std::fputc('>', _out);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const procedure_node &node)
 {
     std::fprintf(_out, "<procedure %s", node.name.data());
@@ -217,10 +217,10 @@ text_generator::process(const procedure_node &node)
     }
 
     std::fputc('>', _out);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const register_node &node)
 {
     std::fputs("<register ", _out);
@@ -260,21 +260,21 @@ text_generator::process(const register_node &node)
     }
 
     std::fputc('>', _out);
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const string_node &node)
 {
     std::fprintf(_out, "<string %s>", node.value.data());
-    return true;
+    return {};
 }
 
-bool
+error
 text_generator::process(const subscript_node &node)
 {
     std::fputs("<subscript ", _out);
     node.value->generate(this);
     std::fputc('>', _out);
-    return true;
+    return {};
 }

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -6,7 +6,40 @@ using namespace zd;
 using namespace zd::gen;
 using namespace zd::par;
 
-#define REQUIRE(expr)                                                          \
+#define ASM(x)                                                                 \
+    if (!as.x)                                                                 \
+    {                                                                          \
+        return gen.make_assembler_error(*_node);                               \
+    }
+
+#define LOAD(arg, dst)                                                         \
+    if (!(arg).load(as, (dst)))                                                \
+    {                                                                          \
+        return gen.make_assembler_error(*(arg).node);                          \
+    }
+
+#define LOAD2(arg, dst1, dst2)                                                 \
+    if (!(arg).load(as, (dst1), (dst2)))                                       \
+    {                                                                          \
+        return gen.make_assembler_error(*(arg).node);                          \
+    }
+
+#define REQUIRE_ARG(arg, x)                                                    \
+    if (!(arg.x))                                                              \
+    {                                                                          \
+        return gen.make_invalid_argument(*(arg).node);                         \
+    }
+
+#define REQUIRE_SUCCESS(x)                                                     \
+    {                                                                          \
+        error __status = (x);                                                  \
+        if (!__status)                                                         \
+        {                                                                      \
+            return __status;                                                   \
+        }                                                                      \
+    }
+
+#define RETURN_IF_FALSE(expr)                                                  \
     if (!(expr))                                                               \
     {                                                                          \
         return false;                                                          \
@@ -17,9 +50,8 @@ zd4_byte::load(x86_assembler &as, cpu_register dst) const
 {
     if (sym)
     {
-        as.mov(cpu_register::si, *sym);
-        as.mov(dst, mreg{cpu_register::si});
-        return true;
+        return as.mov(cpu_register::si, *sym) &&
+               as.mov(dst, mreg{cpu_register::si});
     }
 
     if (cpu_register::invalid != reg)
@@ -54,20 +86,19 @@ zd4_text::load(x86_assembler    &as,
                par::cpu_register dst_buffer,
                par::cpu_register dst_size) const
 {
-    REQUIRE(cpu_register_word == ((unsigned)dst_buffer & 0xFF00));
+    RETURN_IF_FALSE(cpu_register_word == ((unsigned)dst_buffer & 0xFF00));
 
     if (sym)
     {
         if (cpu_register::invalid != dst_size)
         {
-            REQUIRE(as.mov(cpu_register::si, {*sym, +1}));
-            REQUIRE(as.mov(dst_size, mreg{cpu_register::si}));
+            RETURN_IF_FALSE(as.mov(cpu_register::si, {*sym, +1}));
+            RETURN_IF_FALSE(as.mov(dst_size, mreg{cpu_register::si}));
         }
-        REQUIRE(as.mov(dst_buffer, {*sym, +2}));
-        return true;
+        return as.mov(dst_buffer, {*sym, +2});
     }
 
-    REQUIRE(val);
+    RETURN_IF_FALSE(val);
     std::vector<char> data{};
     data.resize(val->size() + 2);
 
@@ -75,10 +106,10 @@ zd4_text::load(x86_assembler    &as,
     *(ptr++) = 0;
     *(ptr++) = '$';
 
-    REQUIRE(as.mov(dst_buffer, data));
+    RETURN_IF_FALSE(as.mov(dst_buffer, data));
     if (cpu_register::invalid != dst_size)
     {
-        REQUIRE(as.mov(dst_size, ptr - data.data() - 2));
+        RETURN_IF_FALSE(as.mov(dst_size, ptr - data.data() - 2));
     }
     return true;
 }
@@ -86,8 +117,8 @@ zd4_text::load(x86_assembler    &as,
 bool
 zd4_text::loadd(x86_assembler &as, par::cpu_register dst) const
 {
-    REQUIRE(cpu_register_word == ((unsigned)dst & 0xFF00));
-    REQUIRE(val);
+    RETURN_IF_FALSE(cpu_register_word == ((unsigned)dst & 0xFF00));
+    RETURN_IF_FALSE(val);
 
     std::vector<char> data{};
     data.resize(val->size() + 1);
@@ -95,8 +126,7 @@ zd4_text::loadd(x86_assembler &as, par::cpu_register dst) const
     auto ptr = val->encode(data.data(), text::encoding::ibm852);
     *ptr = '$';
 
-    REQUIRE(as.mov(dst, data));
-    return true;
+    return as.mov(dst, data);
 }
 
 bool
@@ -104,9 +134,8 @@ zd4_word::load(x86_assembler &as, cpu_register dst) const
 {
     if (sym)
     {
-        as.mov(cpu_register::si, *sym);
-        as.mov(dst, mreg{cpu_register::si});
-        return true;
+        return as.mov(cpu_register::si, *sym) &&
+               as.mov(dst, mreg{cpu_register::si});
     }
 
     if (cpu_register::invalid != reg)
@@ -122,78 +151,80 @@ zd4_word::load(x86_assembler &as, cpu_register dst) const
     return as.mov(dst, val);
 }
 
-bool
+error
 zd4_builtins::Czekaj_w(const zd4_word &czas)
 {
     // INT 15,86 - Elapsed Time Wait (AT and PS/2)
-    REQUIRE(czas.load(as, cpu_register::cx));
-    as.mov(cpu_register::ax, 0x8600);
-    as.mov(cpu_register::dx, 0);
-    as.intr(0x15);
-    return true;
+    LOAD(czas, cpu_register::cx);
+    ASM(mov(cpu_register::ax, 0x8600));
+    ASM(mov(cpu_register::dx, 0));
+    ASM(intr(0x15));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Czysc_b(const zd4_byte &atrybut)
 {
     // INT 10,6 - Scroll Window Up
-    REQUIRE(atrybut.load(as, cpu_register::bh));
-    as.mov(cpu_register::ax, 0x0600);
-    as.mov(cpu_register::cx, 0);
-    as.mov(cpu_register::dx, (24 << 8) | 79);
-    as.intr(0x10);
+    LOAD(atrybut, cpu_register::bh);
+    ASM(mov(cpu_register::ax, 0x0600));
+    ASM(mov(cpu_register::cx, 0));
+    ASM(mov(cpu_register::dx, (24 << 8) | 79));
+    ASM(intr(0x10));
 
     // INT 10,2 - Set Cursor Position
-    as.mov(cpu_register::ah, 2);
-    as.mov(cpu_register::bh, 0);
-    as.mov(cpu_register::dx, 0);
-    as.intr(0x10);
+    ASM(mov(cpu_register::ah, 2));
+    ASM(mov(cpu_register::bh, 0));
+    ASM(mov(cpu_register::dx, 0));
+    ASM(intr(0x10));
 
-    return true;
+    return {};
 }
 
-bool
+error
 zd4_builtins::Czytaj_T(zd4_text &wyjscie)
 {
-    REQUIRE(wyjscie.sym);
-    REQUIRE(zd4_section_udat == wyjscie.sym->section);
+    REQUIRE_ARG(wyjscie, sym);
+    REQUIRE_ARG(wyjscie, sym->section == zd4_section_udat);
 
     // INT 21,A - Buffered Keyboard Input
-    as.mov(cpu_register::ah, 0xA);
-    as.mov(cpu_register::dx, symbol_ref{*wyjscie.sym});
-    as.intr(0x21);
+    ASM(mov(cpu_register::ah, 0xA));
+    ASM(mov(cpu_register::dx, symbol_ref{*wyjscie.sym}));
+    ASM(intr(0x21));
 
-    as.mov(cpu_register::bx, symbol_ref{*wyjscie.sym, +1});
-    as.mov(cpu_register::al, mreg{cpu_register::bx});
-    as.mov(cpu_register::ah, 0);
-    as.inc(cpu_register::bx);
-    as.add(cpu_register::bx, cpu_register::ax);
+    ASM(mov(cpu_register::bx, symbol_ref{*wyjscie.sym, +1}));
+    ASM(mov(cpu_register::al, mreg{cpu_register::bx}));
+    ASM(mov(cpu_register::ah, 0));
+    ASM(inc(cpu_register::bx));
+    ASM(add(cpu_register::bx, cpu_register::ax));
 
-    as.mov(cpu_register::cx, 0x2400); // NUL $
-    as.mov(mreg{cpu_register::bx}, cpu_register::cx);
+    ASM(mov(cpu_register::cx, 0x2400)); // NUL $
+    ASM(mov(mreg{cpu_register::bx}, cpu_register::cx));
 
-    return true;
+    return {};
 }
 
-bool
+error
 zd4_builtins::DoPortu()
 {
-    return as.outb();
+    ASM(outb());
+    return {};
 }
 
-bool
+error
 zd4_builtins::Klawisz()
 {
     // INT 21,7 - Direct Console Input Without Echo
-    as.mov(cpu_register::ah, 7);
-    as.intr(0x21);
-    return true;
+    ASM(mov(cpu_register::ah, 7));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Laduj()
 {
-    return as.lodsb();
+    ASM(lodsb());
+    return {};
 }
 
 // Procedure $Losowa16
@@ -207,13 +238,14 @@ static const uint8_t Losowa16_impl[]{
     0xC3,             // ret
 };
 
-bool
+error
 zd4_builtins::Losowa16()
 {
     auto procedure =
         get_procedure("$Losowa16", Losowa16_impl, sizeof(Losowa16_impl));
-    REQUIRE(procedure);
-    return as.call(*procedure);
+    assert(procedure && "cannot locate a built-in procedure");
+    ASM(call(*procedure));
+    return {};
 }
 
 // Procedure $Losowa8
@@ -227,93 +259,98 @@ static const uint8_t Losowa8_impl[]{
     0xC3,             // ret
 };
 
-bool
+error
 zd4_builtins::Losowa8()
 {
     auto procedure =
         get_procedure("$Losowa8", Losowa8_impl, sizeof(Losowa8_impl));
-    REQUIRE(procedure);
-    return as.call(*procedure);
+    assert(procedure && "cannot locate a built-in procedure");
+    ASM(call(*procedure));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Nic()
 {
-    return as.nop();
+    ASM(nop());
+    return {};
 }
 
-bool
+error
 zd4_builtins::Otworz_ftb(const zd4_file &plik,
                          const zd4_text &nazwa,
                          const zd4_byte &tryb)
 {
     // INT 21,3D - Open File Using Handle
-    REQUIRE(nazwa.load(as, cpu_register::dx));
-    REQUIRE(tryb.load(as, cpu_register::al));
-    as.mov(cpu_register::ah, 0x3D);
-    as.intr(0x21);
+    LOAD(nazwa, cpu_register::dx);
+    LOAD(tryb, cpu_register::al);
+    ASM(mov(cpu_register::ah, 0x3D));
+    ASM(intr(0x21));
 
     // INT 21,46 - Force Duplicate File Handle
-    REQUIRE(plik.load(as, cpu_register::cx));
-    as.mov(cpu_register::bx, cpu_register::ax);
-    as.mov(cpu_register::ah, 0x46);
-    as.intr(0x21);
+    LOAD(plik, cpu_register::cx);
+    ASM(mov(cpu_register::bx, cpu_register::ax));
+    ASM(mov(cpu_register::ah, 0x46));
+    ASM(intr(0x21));
 
-    return true;
+    return {};
 }
 
-bool
+error
 zd4_builtins::Pisz_t(const zd4_text &tekst)
 {
     // INT 21,9 - Print String
     if (tekst.val)
     {
-        REQUIRE(tekst.loadd(as, cpu_register::dx));
+        if (!tekst.loadd(as, cpu_register::dx))
+        {
+            return gen.make_assembler_error(*tekst.node);
+        }
     }
     else
     {
-        REQUIRE(tekst.load(as, cpu_register::dx));
+        LOAD(tekst, cpu_register::dx);
     }
-    as.mov(cpu_register::ah, 9);
-    as.intr(0x21);
-    return true;
+    ASM(mov(cpu_register::ah, 9));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Pisz_tt(const zd4_text &tekst1, const zd4_text &tekst2)
 {
-    REQUIRE(Pisz_t(tekst1));
-    REQUIRE(Pisz_t(tekst2));
-    return true;
+    REQUIRE_SUCCESS(Pisz_t(tekst1));
+    REQUIRE_SUCCESS(Pisz_t(tekst2));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Pisz_ft(const zd4_file &plik, const zd4_text &tekst)
 {
     // INT 21,40 - Write To File or Device Using Handle
-    REQUIRE(plik.load(as, cpu_register::bx));
-    REQUIRE(tekst.load(as, cpu_register::dx, cpu_register::cl));
-    as.mov(cpu_register::ch, 0);
-    as.mov(cpu_register::ah, 0x40);
-    as.intr(0x21);
-    return true;
+    LOAD(plik, cpu_register::bx);
+    LOAD2(tekst, cpu_register::dx, cpu_register::cl);
+    ASM(mov(cpu_register::ch, 0));
+    ASM(mov(cpu_register::ah, 0x40));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Pisz_ftt(const zd4_file &plik,
                        const zd4_text &tekst1,
                        const zd4_text &tekst2)
 {
-    REQUIRE(Pisz_ft(plik, tekst1));
-    REQUIRE(Pisz_ft(plik, tekst2));
-    return true;
+    REQUIRE_SUCCESS(Pisz_ft(plik, tekst1));
+    REQUIRE_SUCCESS(Pisz_ft(plik, tekst2));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Pisz_w(const zd4_word &liczba)
 {
-    REQUIRE(!liczba.sym);
-    REQUIRE(cpu_register::invalid == liczba.reg);
+    REQUIRE_ARG(liczba, sym == nullptr);
+    REQUIRE_ARG(liczba, reg == cpu_register::invalid);
 
     char buff[6];
     std::snprintf(buff, sizeof(buff), "%u", liczba.val);
@@ -321,11 +358,11 @@ zd4_builtins::Pisz_w(const zd4_word &liczba)
     return Pisz_t(&str);
 }
 
-bool
+error
 zd4_builtins::Pisz_fw(const zd4_file &plik, const zd4_word &liczba)
 {
-    REQUIRE(!liczba.sym);
-    REQUIRE(cpu_register::invalid == liczba.reg);
+    REQUIRE_ARG(liczba, sym == nullptr);
+    REQUIRE_ARG(liczba, reg == cpu_register::invalid);
 
     char buff[6];
     std::snprintf(buff, sizeof(buff), "%u", liczba.val);
@@ -333,45 +370,45 @@ zd4_builtins::Pisz_fw(const zd4_file &plik, const zd4_word &liczba)
     return Pisz_ft(plik, &str);
 }
 
-bool
+error
 zd4_builtins::PiszL_t(const zd4_text &tekst)
 {
-    REQUIRE(Pisz_t(tekst));
-    REQUIRE(Pisz());
-    return true;
+    REQUIRE_SUCCESS(Pisz_t(tekst));
+    REQUIRE_SUCCESS(Pisz());
+    return {};
 }
 
-bool
+error
 zd4_builtins::PiszL_tt(const zd4_text &tekst1, const zd4_text &tekst2)
 {
-    REQUIRE(Pisz_t(tekst1));
-    REQUIRE(PiszL_t(tekst2));
-    return true;
+    REQUIRE_SUCCESS(Pisz_t(tekst1));
+    REQUIRE_SUCCESS(PiszL_t(tekst2));
+    return {};
 }
 
-bool
+error
 zd4_builtins::PiszL_ft(const zd4_file &plik, const zd4_text &tekst)
 {
-    REQUIRE(Pisz_ft(plik, tekst));
-    REQUIRE(Pisz_f(plik));
-    return true;
+    REQUIRE_SUCCESS(Pisz_ft(plik, tekst));
+    REQUIRE_SUCCESS(Pisz_f(plik));
+    return {};
 }
 
-bool
+error
 zd4_builtins::PiszL_ftt(const zd4_file &plik,
                         const zd4_text &tekst1,
                         const zd4_text &tekst2)
 {
-    REQUIRE(Pisz_ft(plik, tekst1));
-    REQUIRE(PiszL_ft(plik, tekst2));
-    return true;
+    REQUIRE_SUCCESS(Pisz_ft(plik, tekst1));
+    REQUIRE_SUCCESS(PiszL_ft(plik, tekst2));
+    return {};
 }
 
-bool
+error
 zd4_builtins::PiszL_w(const zd4_word &liczba)
 {
-    REQUIRE(!liczba.sym);
-    REQUIRE(cpu_register::invalid == liczba.reg);
+    REQUIRE_ARG(liczba, sym == nullptr);
+    REQUIRE_ARG(liczba, reg == cpu_register::invalid);
 
     char buff[8];
     std::snprintf(buff, sizeof(buff), "%u\r\n", liczba.val);
@@ -379,11 +416,11 @@ zd4_builtins::PiszL_w(const zd4_word &liczba)
     return Pisz_t(&str);
 }
 
-bool
+error
 zd4_builtins::PiszL_fw(const zd4_file &plik, const zd4_word &liczba)
 {
-    REQUIRE(!liczba.sym);
-    REQUIRE(cpu_register::invalid == liczba.reg);
+    REQUIRE_ARG(liczba, sym == nullptr);
+    REQUIRE_ARG(liczba, reg == cpu_register::invalid);
 
     char buff[8];
     std::snprintf(buff, sizeof(buff), "%u\r\n", liczba.val);
@@ -414,208 +451,210 @@ static const uint8_t Pisz8_impl[]{
     0xC3,                   //      ret
 };
 
-bool
+error
 zd4_builtins::Pisz8_b(const zd4_byte &liczba)
 {
-    REQUIRE(liczba.load(as, cpu_register::cl));
+    LOAD(liczba, cpu_register::cl);
     auto procedure = get_procedure("$Pisz8", Pisz8_impl, sizeof(Pisz8_impl));
-    REQUIRE(procedure);
-    return as.call(*procedure);
+    assert(procedure && "cannot locate a built-in procedure");
+    ASM(call(*procedure));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Pisz8_t(const zd4_text &tekst)
 {
-    REQUIRE(tekst.load(as, cpu_register::si));
-    as.mov(cpu_register::cl, mreg{cpu_register::si});
+    LOAD(tekst, cpu_register::si);
+    ASM(mov(cpu_register::cl, mreg{cpu_register::si}));
     return Pisz8_b(cpu_register::cl);
 }
 
-bool
+error
 zd4_builtins::PiszZnak_bbw(const zd4_byte &znak,
                            const zd4_byte &atrybut,
                            const zd4_word &powtorzenia)
 {
     // INT 10,9 - Write Character and Attribute at Cursor Position
-    REQUIRE(znak.load(as, cpu_register::al));
-    REQUIRE(atrybut.load(as, cpu_register::bl));
-    REQUIRE(powtorzenia.load(as, cpu_register::cx));
-    as.mov(cpu_register::ah, 0x09);
-    as.mov(cpu_register::bh, 0);
-    as.intr(0x10);
-    return true;
+    LOAD(znak, cpu_register::al);
+    LOAD(atrybut, cpu_register::bl);
+    LOAD(powtorzenia, cpu_register::cx);
+    ASM(mov(cpu_register::ah, 0x09));
+    ASM(mov(cpu_register::bh, 0));
+    ASM(intr(0x10));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Pozycja_bb(const zd4_byte &kolumna, const zd4_byte &wiersz)
 {
     // INT 10,2 - Set Cursor Position
-    REQUIRE(kolumna.load(as, cpu_register::dl));
-    REQUIRE(wiersz.load(as, cpu_register::dh));
-    as.mov(cpu_register::ah, 2);
-    as.mov(cpu_register::bh, 0);
-    as.intr(0x10);
-    return true;
+    LOAD(kolumna, cpu_register::dl);
+    LOAD(wiersz, cpu_register::dh);
+    ASM(mov(cpu_register::ah, 2));
+    ASM(mov(cpu_register::bh, 0));
+    ASM(intr(0x10));
+    return {};
 }
 
-bool
+error
 zd4_builtins::PokazMysz()
 {
     // INT 33,1 - Show Mouse Cursor
-    as.mov(cpu_register::ax, 1);
-    as.intr(0x33);
-    return true;
+    ASM(mov(cpu_register::ax, 1));
+    ASM(intr(0x33));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Przerwanie_b(const zd4_byte &numer)
 {
-    REQUIRE(cpu_register::invalid == numer.reg);
-    REQUIRE(!numer.sym);
-    return as.intr(numer.val);
+    REQUIRE_ARG(numer, reg == cpu_register::invalid);
+    REQUIRE_ARG(numer, sym == nullptr);
+    ASM(intr(numer.val));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Punkt_wwb(const zd4_word &kolumna,
                         const zd4_word &wiersz,
                         const zd4_byte &kolor)
 {
     // INT 10,C - Write Graphics Pixel at Coordinate
-    REQUIRE(kolumna.load(as, cpu_register::cx));
-    REQUIRE(wiersz.load(as, cpu_register::dx));
-    REQUIRE(kolor.load(as, cpu_register::al));
-    as.mov(cpu_register::ah, 0xC);
-    as.mov(cpu_register::bx, 0);
-    as.intr(0x10);
-    return true;
+    LOAD(kolumna, cpu_register::cx);
+    LOAD(wiersz, cpu_register::dx);
+    LOAD(kolor, cpu_register::al);
+    ASM(mov(cpu_register::ah, 0xC));
+    ASM(mov(cpu_register::bx, 0));
+    ASM(intr(0x10));
+    return {};
 }
 
-bool
+error
 zd4_builtins::StanPrzyciskow()
 {
     // INT 33,3 - Get Mouse Position and Button Status
-    as.mov(cpu_register::ax, 3);
-    as.intr(0x33);
-    return true;
+    ASM(mov(cpu_register::ax, 3));
+    ASM(intr(0x33));
+    return {};
 }
 
-bool
+error
 zd4_builtins::StanPrzyciskow_t(const zd4_text &tekst)
 {
-    REQUIRE(!tekst.sym);
-    REQUIRE(tekst.val);
-    REQUIRE('!' == *tekst.val->data());
+    REQUIRE_ARG(tekst, sym == nullptr);
+    REQUIRE_ARG(tekst, val);
+    REQUIRE_ARG(tekst, val->data()[0] == '!');
 
-    REQUIRE(StanPrzyciskow());
-    as.mov(cpu_register::ax, cpu_register::cx);
-    as.mov(cpu_register::cl, 3);
-    as.shr(cpu_register::ax, cpu_register::cl);
-    as.shr(cpu_register::dx, cpu_register::cl);
-    as.mov(cpu_register::cx, cpu_register::ax);
-    return true;
+    REQUIRE_SUCCESS(StanPrzyciskow());
+    ASM(mov(cpu_register::ax, cpu_register::cx));
+    ASM(mov(cpu_register::cl, 3));
+    ASM(shr(cpu_register::ax, cpu_register::cl));
+    ASM(shr(cpu_register::dx, cpu_register::cl));
+    ASM(mov(cpu_register::cx, cpu_register::ax));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Tryb_b(const zd4_byte &tryb)
 {
     // INT 10,0 - Set Video Mode
-    REQUIRE(tryb.load(as, cpu_register::al));
-    as.mov(cpu_register::ah, 0);
-    as.intr(0x10);
-    return true;
+    LOAD(tryb, cpu_register::al);
+    ASM(mov(cpu_register::ah, 0));
+    ASM(intr(0x10));
+    return {};
 }
 
-bool
+error
 zd4_builtins::TworzKatalog_t(const zd4_text &tekst)
 {
     // INT 21,39 - Create Subdirectory (mkdir)
-    REQUIRE(tekst.load(as, cpu_register::dx));
-    as.mov(cpu_register::ah, 0x39);
-    as.intr(0x21);
-    return true;
+    LOAD(tekst, cpu_register::dx);
+    ASM(mov(cpu_register::ah, 0x39));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::TworzPlik_t(const zd4_text &tekst)
 {
     // INT 21,3C - Create File Using Handle
-    REQUIRE(tekst.load(as, cpu_register::dx));
-    as.mov(cpu_register::ah, 0x3C);
-    as.intr(0x21);
-    return true;
+    LOAD(tekst, cpu_register::dx);
+    ASM(mov(cpu_register::ah, 0x3C));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::UkryjMysz()
 {
     // INT 33,2 - Hide Mouse Cursor
-    as.mov(cpu_register::ax, 2);
-    as.intr(0x33);
-    return true;
+    ASM(mov(cpu_register::ax, 2));
+    ASM(intr(0x33));
+    return {};
 }
 
-bool
+error
 zd4_builtins::UsunKatalog_t(const zd4_text &tekst)
 {
     // INT 21,3A - Remove Subdirectory (rmdir)
-    REQUIRE(tekst.load(as, cpu_register::dx));
-    as.mov(cpu_register::ah, 0x3A);
-    as.intr(0x21);
-    return true;
+    LOAD(tekst, cpu_register::dx);
+    ASM(mov(cpu_register::ah, 0x3A));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::UsunPlik_t(const zd4_text &tekst)
 {
     // INT 21,41 - Delete File
-    REQUIRE(tekst.load(as, cpu_register::dx));
-    as.mov(cpu_register::ah, 0x41);
-    as.intr(0x21);
-    return true;
+    LOAD(tekst, cpu_register::dx);
+    ASM(mov(cpu_register::ah, 0x41));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::Zamknij_f(const zd4_file &plik)
 {
     // INT 21,3E - Close File Using Handle
-    REQUIRE(plik.load(as, cpu_register::bx));
-    as.mov(cpu_register::ah, 0x3E);
-    as.intr(0x21);
-    return true;
+    LOAD(plik, cpu_register::bx);
+    ASM(mov(cpu_register::ah, 0x3E));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::ZmienKatalog_t(const zd4_text &tekst)
 {
     // INT 21,3B - Change Current Directory (chdir)
-    REQUIRE(tekst.load(as, cpu_register::dx));
-    as.mov(cpu_register::ah, 0x3B);
-    as.intr(0x21);
-    return true;
+    LOAD(tekst, cpu_register::dx);
+    ASM(mov(cpu_register::ah, 0x3B));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::ZmienNazwe_tt(const zd4_text &stara, const zd4_text &nowa)
 {
     // INT 21,56 - Rename File
-    REQUIRE(stara.load(as, cpu_register::dx));
-    REQUIRE(nowa.load(as, cpu_register::di));
-    as.push(x86_segment::ds);
-    as.pop(x86_segment::es);
-    as.mov(cpu_register::ah, 0x56);
-    as.intr(0x21);
-    return true;
+    LOAD(stara, cpu_register::dx);
+    LOAD(nowa, cpu_register::di);
+    ASM(push(x86_segment::ds));
+    ASM(pop(x86_segment::es));
+    ASM(mov(cpu_register::ah, 0x56));
+    ASM(intr(0x21));
+    return {};
 }
 
-bool
+error
 zd4_builtins::ZmienNazwe_t(const zd4_text &stara_nowa)
 {
-    REQUIRE(!stara_nowa.sym);
-    REQUIRE(stara_nowa.val);
+    REQUIRE_ARG(stara_nowa, sym == nullptr);
+    REQUIRE_ARG(stara_nowa, val);
 
     // Irregular string literal pair
     auto comma = std::find(stara_nowa.val->begin(), stara_nowa.val->end(), ',');
-    REQUIRE(stara_nowa.val->end() != comma);
+    REQUIRE_ARG(stara_nowa, val->end() != comma);
 
     auto str_it = stara_nowa.val->begin();
 
@@ -640,10 +679,11 @@ zd4_builtins::ZmienNazwe_t(const zd4_text &stara_nowa)
     return ZmienNazwe_tt(&stara, &nowa);
 }
 
-bool
+error
 zd4_builtins::ZPortu()
 {
-    return as.inb();
+    ASM(inb());
+    return {};
 }
 
 symbol *
@@ -706,25 +746,29 @@ _matches_args(const char *signature, const node_list &args)
         {
         case 'b':
         case 'w':
-            REQUIRE(arg->is<number_node>() || arg->is<register_node>() ||
-                    (arg->is<object_node>() &&
-                     (object_type::text != arg->as<object_node>()->type)));
+            RETURN_IF_FALSE(
+                arg->is<number_node>() || arg->is<register_node>() ||
+                (arg->is<object_node>() &&
+                 (object_type::text != arg->as<object_node>()->type)));
             break;
 
         case 'f':
-            REQUIRE(arg->is<subscript_node>() &&
-                    arg->as<subscript_node>()->value->is<number_node>());
+            RETURN_IF_FALSE(
+                arg->is<subscript_node>() &&
+                arg->as<subscript_node>()->value->is<number_node>());
             break;
 
         case 't':
-            REQUIRE(arg->is<string_node>() ||
-                    (arg->is<object_node>() &&
-                     (object_type::text == arg->as<object_node>()->type)));
+            RETURN_IF_FALSE(
+                arg->is<string_node>() ||
+                (arg->is<object_node>() &&
+                 (object_type::text == arg->as<object_node>()->type)));
             break;
 
         case 'T':
-            REQUIRE(arg->is<object_node>() &&
-                    (object_type::text == arg->as<object_node>()->type));
+            RETURN_IF_FALSE(
+                arg->is<object_node>() &&
+                (object_type::text == arg->as<object_node>()->type));
             break;
 
         default:
@@ -747,17 +791,17 @@ get_arg<zd4_byte>(zd4_builtins *this_, node &arg)
 {
     if (arg.is<number_node>())
     {
-        return arg.as<number_node>()->value;
+        return zd4_byte(arg.as<number_node>()->value, &arg);
     }
 
     if (arg.is<register_node>())
     {
-        return arg.as<register_node>()->reg;
+        return {arg.as<register_node>()->reg, &arg};
     }
 
     if (arg.is<object_node>())
     {
-        return &this_->gen.get_symbol(arg.as<object_node>()->name);
+        return {&this_->gen.get_symbol(arg.as<object_node>()->name), &arg};
     }
 
     assert(false && "unexpected argument node type for a byte");
@@ -768,7 +812,7 @@ template <>
 zd4_file
 get_arg<zd4_file>(zd4_builtins *this_, node &arg)
 {
-    return arg.as<subscript_node>()->value->as<number_node>()->value;
+    return zd4_file(arg.as<subscript_node>()->value->as<number_node>()->value, &arg);
 }
 
 template <>
@@ -777,12 +821,12 @@ get_arg<zd4_text>(zd4_builtins *this_, node &arg)
 {
     if (arg.is<string_node>())
     {
-        return &arg.as<string_node>()->value;
+        return {&arg.as<string_node>()->value, &arg};
     }
 
     if (arg.is<object_node>())
     {
-        return &this_->gen.get_symbol(arg.as<object_node>()->name);
+        return {&this_->gen.get_symbol(arg.as<object_node>()->name), &arg};
     }
 
     assert(false && "unexpected argument node type for a text");
@@ -795,33 +839,33 @@ get_arg<zd4_word>(zd4_builtins *this_, node &arg)
 {
     if (arg.is<number_node>())
     {
-        return arg.as<number_node>()->value;
+        return zd4_word(arg.as<number_node>()->value, &arg);
     }
 
     if (arg.is<register_node>())
     {
-        return arg.as<register_node>()->reg;
+        return {arg.as<register_node>()->reg, &arg};
     }
 
     if (arg.is<object_node>())
     {
-        return &this_->gen.get_symbol(arg.as<object_node>()->name);
+        return {&this_->gen.get_symbol(arg.as<object_node>()->name), &arg};
     }
 
     assert(false && "unexpected argument node type for a word");
     return 0xFFFF;
 }
 
-bool
-invoke(zd4_builtins *this_, bool (zd4_builtins::*mfp)(), const node_list &args)
+error
+invoke(zd4_builtins *this_, error (zd4_builtins::*mfp)(), const node_list &args)
 {
     return (this_->*mfp)();
 }
 
 template <typename Arg1>
-bool
-invoke(zd4_builtins    *this_,
-       bool             (zd4_builtins::*mfp)(Arg1),
+error
+invoke(zd4_builtins *this_,
+       error (zd4_builtins::*mfp)(Arg1),
        const node_list &args)
 {
     auto it = args.begin();
@@ -830,9 +874,9 @@ invoke(zd4_builtins    *this_,
 }
 
 template <typename Arg1, typename Arg2>
-bool
-invoke(zd4_builtins    *this_,
-       bool             (zd4_builtins::*mfp)(Arg1, Arg2),
+error
+invoke(zd4_builtins *this_,
+       error (zd4_builtins::*mfp)(Arg1, Arg2),
        const node_list &args)
 {
     auto it = args.begin();
@@ -842,9 +886,9 @@ invoke(zd4_builtins    *this_,
 }
 
 template <typename Arg1, typename Arg2, typename Arg3>
-bool
-invoke(zd4_builtins    *this_,
-       bool             (zd4_builtins::*mfp)(Arg1, Arg2, Arg3),
+error
+invoke(zd4_builtins *this_,
+       error (zd4_builtins::*mfp)(Arg1, Arg2, Arg3),
        const node_list &args)
 {
     auto it = args.begin();
@@ -857,16 +901,18 @@ invoke(zd4_builtins    *this_,
 #define INVOKE_IF_MATCH(mf)                                                    \
     {                                                                          \
         auto __signature = #mf;                                                \
-        if (_matches_name(__signature, name) &&                                \
-            _matches_args(__signature, args))                                  \
+        if (_matches_name(__signature, node.callee) &&                         \
+            _matches_args(__signature, node.arguments))                        \
         {                                                                      \
-            return invoke(this, &zd4_builtins::mf, args);                      \
+            return invoke(this, &zd4_builtins::mf, node.arguments);            \
         }                                                                      \
     }
 
-bool
-zd4_builtins::dispatch(const ustring &name, const node_list &args)
+error
+zd4_builtins::dispatch(const call_node &node)
 {
+    _node = &node;
+
     INVOKE_IF_MATCH(Czekaj_w);
     INVOKE_IF_MATCH(Czysc);
     INVOKE_IF_MATCH(Czysc_b);
@@ -918,5 +964,6 @@ zd4_builtins::dispatch(const ustring &name, const node_list &args)
     INVOKE_IF_MATCH(ZmienNazwe_tt);
     INVOKE_IF_MATCH(ZmienNazwe_t);
     INVOKE_IF_MATCH(ZPortu);
-    return false;
+
+    return error{gen, zd4_generator::error_code::not_a_builtin};
 }

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -761,6 +761,7 @@ get_arg<zd4_byte>(zd4_builtins *this_, node &arg)
     }
 
     assert(false && "unexpected argument node type for a byte");
+    return 0xFF;
 }
 
 template <>
@@ -785,6 +786,7 @@ get_arg<zd4_text>(zd4_builtins *this_, node &arg)
     }
 
     assert(false && "unexpected argument node type for a text");
+    return static_cast<symbol *>(nullptr);
 }
 
 template <>
@@ -807,6 +809,7 @@ get_arg<zd4_word>(zd4_builtins *this_, node &arg)
     }
 
     assert(false && "unexpected argument node type for a word");
+    return 0xFFFF;
 }
 
 bool
@@ -817,8 +820,8 @@ invoke(zd4_builtins *this_, bool (zd4_builtins::*mfp)(), const node_list &args)
 
 template <typename Arg1>
 bool
-invoke(zd4_builtins *this_,
-       bool (zd4_builtins::*mfp)(Arg1),
+invoke(zd4_builtins    *this_,
+       bool             (zd4_builtins::*mfp)(Arg1),
        const node_list &args)
 {
     auto it = args.begin();
@@ -828,8 +831,8 @@ invoke(zd4_builtins *this_,
 
 template <typename Arg1, typename Arg2>
 bool
-invoke(zd4_builtins *this_,
-       bool (zd4_builtins::*mfp)(Arg1, Arg2),
+invoke(zd4_builtins    *this_,
+       bool             (zd4_builtins::*mfp)(Arg1, Arg2),
        const node_list &args)
 {
     auto it = args.begin();
@@ -840,8 +843,8 @@ invoke(zd4_builtins *this_,
 
 template <typename Arg1, typename Arg2, typename Arg3>
 bool
-invoke(zd4_builtins *this_,
-       bool (zd4_builtins::*mfp)(Arg1, Arg2, Arg3),
+invoke(zd4_builtins    *this_,
+       bool             (zd4_builtins::*mfp)(Arg1, Arg2, Arg3),
        const node_list &args)
 {
     auto it = args.begin();

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -37,14 +37,16 @@ zd4_generator::process(const par::assignment_node &node)
         if (node.source->is<number_node>())
         {
             ASM(mov(dst, (uint16_t)node.source->as<number_node>()->value),
-                node);
+                *node.source);
             return {};
         }
 
         if (node.source->is<object_node>())
         {
-            ASM(push(get_symbol(node.source->as<object_node>()->name)), node);
-            ASM(pop(get_symbol(node.target->as<object_node>()->name)), node);
+            ASM(push(get_symbol(node.source->as<object_node>()->name)),
+                *node.source);
+            ASM(pop(get_symbol(node.target->as<object_node>()->name)),
+                *node.source);
             return {};
         }
 
@@ -55,9 +57,9 @@ zd4_generator::process(const par::assignment_node &node)
             if ((symbol_type::var_byte != dst.type) &&
                 (cpu_register_word != ((unsigned)src_reg & 0xFF00)))
             {
-                ASM(mov(mreg{cpu_register::di}, 0), node);
+                ASM(mov(mreg{cpu_register::di}, 0), *node.target);
             }
-            ASM(mov(mreg{cpu_register::di}, src_reg), node);
+            ASM(mov(mreg{cpu_register::di}, src_reg), *node.source);
             return {};
         }
 
@@ -112,7 +114,7 @@ zd4_generator::process(const par::assignment_node &node)
         else if (node.source->is<number_node>())
         {
             ASM(mov(dst, (uint16_t)node.source->as<number_node>()->value),
-                node);
+                *node.source);
             return {};
         }
 
@@ -326,7 +328,7 @@ zd4_generator::process(const par::jump_node &node)
     CAST_NODE_OR_FAIL(label, node.target);
 
     auto &symbol = get_symbol(label->name);
-    ASM(jmp(symbol), node);
+    ASM(jmp(symbol), *label);
 
     return {};
 }

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -23,6 +23,8 @@ using namespace zd::par;
 bool
 zd4_generator::process(const par::assignment_node &node)
 {
+    set_position(node);
+
     if (node.target->is<object_node>())
     {
         auto  target = node.target->as<object_node>();
@@ -111,6 +113,8 @@ zd4_generator::process(const par::assignment_node &node)
 bool
 zd4_generator::process(const par::call_node &node)
 {
+    set_position(node);
+
     zd4_builtins builtins{*this};
     if (builtins.dispatch(node.callee, node.arguments))
     {
@@ -129,6 +133,8 @@ zd4_generator::process(const par::call_node &node)
 bool
 zd4_generator::process(const par::condition_node &node)
 {
+    set_position(node);
+
     jump_node *jump;
     CAST_NODE_OR_FAIL(jump, node.action);
 
@@ -157,6 +163,8 @@ zd4_generator::process(const par::condition_node &node)
 bool
 zd4_generator::process(const par::declaration_node &node)
 {
+    set_position(node);
+
     object_node     *target{nullptr};
     assignment_node *assignment{nullptr};
 
@@ -279,6 +287,8 @@ zd4_generator::process(const par::declaration_node &node)
 bool
 zd4_generator::process(const par::end_node &node)
 {
+    set_position(node);
+
     if (node.name.empty())
     {
         _as.mov(cpu_register::ah, 0x4C);
@@ -290,8 +300,10 @@ zd4_generator::process(const par::end_node &node)
 }
 
 bool
-zd::gen::zd4_generator::process(const par::emit_node &node)
+zd4_generator::process(const par::emit_node &node)
 {
+    set_position(node);
+
     _curr_code->emit(node.bytes.data(), node.bytes.size());
     return true;
 }
@@ -299,6 +311,8 @@ zd::gen::zd4_generator::process(const par::emit_node &node)
 bool
 zd4_generator::process(const par::jump_node &node)
 {
+    set_position(node);
+
     label_node *label;
     CAST_NODE_OR_FAIL(label, node.target);
 
@@ -311,6 +325,8 @@ zd4_generator::process(const par::jump_node &node)
 bool
 zd4_generator::process(const par::label_node &node)
 {
+    set_position(node);
+
     return set_symbol(node.name, symbol_type::label,
                       static_cast<zd4_known_section>(
                           std::distance(_codes.begin(), _curr_code)),
@@ -320,6 +336,8 @@ zd4_generator::process(const par::label_node &node)
 bool
 zd4_generator::process(const par::operation_node &node)
 {
+    set_position(node);
+
     switch (node.op)
     {
     case operation::add: {
@@ -416,6 +434,8 @@ zd4_generator::process(const par::operation_node &node)
 bool
 zd4_generator::process(const par::procedure_node &node)
 {
+    set_position(node);
+
     nesting_guard nested{*this};
 
     if (!set_symbol(node.name, symbol_type::procedure,

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -500,6 +500,14 @@ zd4_generator::get_cname(const ustring &name)
     return cname;
 }
 
+void
+zd4_generator::set_position(const par::node &node)
+{
+    _path = *node.code_path;
+    _line = node.code_line;
+    _column = node.code_column;
+}
+
 symbol &
 zd4_generator::get_symbol(const ustring &name)
 {

--- a/zdc/src/zd/gen/zd4_generator.cpp
+++ b/zdc/src/zd/gen/zd4_generator.cpp
@@ -126,9 +126,12 @@ error
 zd4_generator::process(const par::call_node &node)
 {
     zd4_builtins builtins{*this};
-    if (builtins.dispatch(node.callee, node.arguments))
+
+    set_position(node);
+    error status = builtins.dispatch(node);
+    if (status || !status.is<zd4_generator>(error_code::not_a_builtin))
     {
-        return {};
+        return status;
     }
 
     if (node.arguments.empty())
@@ -630,6 +633,13 @@ zd4_generator::make_string_too_long(const par::string_node &node)
 {
     set_position(node);
     return error{*this, error_code::string_too_long};
+}
+
+error
+zd4_generator::make_invalid_argument(const par::node &node)
+{
+    set_position(node);
+    return error{*this, error_code::invalid_argument};
 }
 
 error

--- a/zdc/src/zd/messagep.cpp
+++ b/zdc/src/zd/messagep.cpp
@@ -10,6 +10,7 @@
 
 #define ARGV1(argv) (argv)[0]
 #define ARGV2(argv) ARGV1(argv), (argv)[1]
+#define ARGV3(argv) ARGV2(argv), (argv)[2]
 
 #define CASE_PRINT_ARGS(num, ptr, fmt, argv, ret)                              \
     case num:                                                                  \
@@ -70,6 +71,7 @@ message::retrieve(uint16_t ordinal, size_t argc, const uintptr_t *argv)
     {
         CASE_PRINT_ARGS(1, &ptr, fmt, argv, length);
         CASE_PRINT_ARGS(2, &ptr, fmt, argv, length);
+        CASE_PRINT_ARGS(3, &ptr, fmt, argv, length);
     default:
         length = ::ASPRINTF(&ptr, "%s", fmt);
     }

--- a/zdc/src/zd/par/CMakeLists.txt
+++ b/zdc/src/zd/par/CMakeLists.txt
@@ -1,1 +1,2 @@
+target_sources(zdc PRIVATE node.cpp)
 target_sources(zdc PRIVATE parser.cpp)

--- a/zdc/src/zd/par/node.cpp
+++ b/zdc/src/zd/par/node.cpp
@@ -1,5 +1,36 @@
 #include <zd/par/node.hpp>
 
+using namespace zd;
+using namespace zd::par;
+
+#define RETURN_IF_IS(n, type, ret)                                             \
+    if ((n).is<type>())                                                        \
+    {                                                                          \
+        return (ret);                                                          \
+    }
+
+const char *
+zd::to_cstr(const par::node &node)
+{
+    RETURN_IF_IS(node, assignment_node, "assignemnt");
+    RETURN_IF_IS(node, call_node, "call");
+    RETURN_IF_IS(node, condition_node, "condition");
+    RETURN_IF_IS(node, declaration_node, "declaration");
+    RETURN_IF_IS(node, emit_node, "emit");
+    RETURN_IF_IS(node, end_node, "end");
+    RETURN_IF_IS(node, include_node, "include");
+    RETURN_IF_IS(node, jump_node, "jump");
+    RETURN_IF_IS(node, label_node, "label");
+    RETURN_IF_IS(node, number_node, "number");
+    RETURN_IF_IS(node, object_node, "object");
+    RETURN_IF_IS(node, operation_node, "operation");
+    RETURN_IF_IS(node, procedure_node, "procedure");
+    RETURN_IF_IS(node, register_node, "register");
+    RETURN_IF_IS(node, string_node, "string");
+    RETURN_IF_IS(node, subscript_node, "subscript");
+    return nullptr;
+}
+
 const char *
 zd::to_cstr(zd::par::operation op)
 {

--- a/zdc/src/zd/par/node.cpp
+++ b/zdc/src/zd/par/node.cpp
@@ -1,0 +1,17 @@
+#include <zd/par/node.hpp>
+
+const char *
+zd::to_cstr(zd::par::operation op)
+{
+    switch (op)
+    {
+    case par::operation::add:
+        return "add";
+    case par::operation::compare:
+        return "compare";
+    case par::operation::subtract:
+        return "subtract";
+    }
+
+    return nullptr;
+}

--- a/zdc/src/zdc.cpp
+++ b/zdc/src/zdc.cpp
@@ -127,7 +127,14 @@ action_compiler(zd::lex::lexer &lexer, std::FILE *output)
         return status;
     }
 
-    generator.link(output);
+    auto link_ret = generator.link(output);
+    if (!link_ret)
+    {
+        zd::error err = std::move(link_ret.error());
+        print_error(err);
+        return 1;
+    }
+
     return 0;
 }
 
@@ -262,10 +269,15 @@ void
 print_error(const zd::error &err)
 {
     auto path = err.file().empty() ? "input" : err.file().data();
-    std::fprintf(stderr, "%s:%u:", path, err.line());
-    if (err.column())
+    std::fprintf(stderr, "%s:", path);
+    if (err.line())
     {
-        std::fprintf(stderr, "%u:", err.column());
+        std::fprintf(stderr, "%u:", err.line());
+
+        if (err.column())
+        {
+            std::fprintf(stderr, "%u:", err.column());
+        }
     }
 
     std::fputc(' ', stderr);

--- a/zdc/src/zdc.cpp
+++ b/zdc/src/zdc.cpp
@@ -228,14 +228,10 @@ action_generator(zd::lex::lexer     &lexer,
             }
         }
 
-        if (!node->generate(generator))
+        zd::error status = node->generate(generator);
+        if (!status)
         {
-            // Text generator doesn't err anyways
-            auto zd4 = static_cast<zd::gen::zd4_generator *>(generator);
-            std::fprintf(stderr, "%s:%u:%u: generator error!\n",
-                         zd4->get_path().empty() ? "input"
-                                                 : zd4->get_path().data(),
-                         zd4->get_line(), zd4->get_column());
+            print_error(status);
             return 1;
         }
 

--- a/zdc/src/zdc.cpp
+++ b/zdc/src/zdc.cpp
@@ -230,7 +230,13 @@ action_generator(zd::lex::lexer     &lexer,
 
         if (!node->generate(generator))
         {
-            std::fputs("generator error!\n", stderr);
+            // Text generator doesn't err anyways
+            auto zd4 = static_cast<zd::gen::zd4_generator *>(generator);
+            std::fprintf(stderr, "%s:%u:%u: generator error!\n",
+                         zd4->get_path().empty() ? "input"
+                                                 : zd4->get_path().data(),
+                         zd4->get_line(), zd4->get_column());
+            return 1;
         }
 
         if (separator)

--- a/zdc/src/zdc.cpp
+++ b/zdc/src/zdc.cpp
@@ -7,6 +7,8 @@
 #include <zd/message.hpp>
 #include <zd/par/parser.hpp>
 
+#include "zdc.hpp"
+
 typedef bool (*node_callback)(zd::par::node *, void *);
 
 static int
@@ -83,8 +85,9 @@ main(int argc, char *argv[])
     {
         if (!*opt_output)
         {
-            std::fputs("error: no output file name provided (argument -o)\n",
-                       stderr);
+            zd::message::retrieve(MSG_ERROR).print(stderr);
+            zd::message::retrieve(MSG_NO_OUTPUT).print(stderr);
+            std::fputs("\n", stderr);
             return 1;
         }
 
@@ -109,7 +112,7 @@ main(int argc, char *argv[])
         return action_generator(lexer, &generator, "");
     }
 
-    std::fprintf(stderr, "unknown action %c\n", *opt_action);
+    assert(false && "unhandled action");
     return 1;
 }
 
@@ -259,11 +262,16 @@ void
 print_error(const zd::error &err)
 {
     auto path = err.file().empty() ? "input" : err.file().data();
-    std::fprintf(stderr, "%s:%u:%u: error: ", path, err.line(), err.column());
+    std::fprintf(stderr, "%s:%u:", path, err.line());
+    if (err.column())
+    {
+        std::fprintf(stderr, "%u:", err.column());
+    }
 
+    std::fputc(' ', stderr);
+    zd::message::retrieve(MSG_ERROR).print(stderr);
     zd::message::retrieve((err.origin() << 8) | err.ordinal(), err.size(),
                           err.begin())
         .print(stderr);
-
     std::fputs("\n", stderr);
 }

--- a/zdc/src/zdc.hpp
+++ b/zdc/src/zdc.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+#define MSG_ERROR     0x8000
+#define MSG_NO_OUTPUT 0x8001

--- a/zdc/src/zdc.mc
+++ b/zdc/src/zdc.mc
@@ -75,3 +75,45 @@ MessageId=0x0308
 Language=English
 unexpected character %1!u! in the emit directive
 .
+
+; // Generator errors
+
+MessageId=0x0401
+Language=English
+unexpected node
+.
+
+MessageId=0x0402
+Language=English
+cannot %1!S! this pair of operands
+.
+
+MessageId=0x0403
+Language=English
+cannot assign this pair of target and source
+.
+
+MessageId=0x0404
+Language=English
+cannot assign variable %1!S! at its declaration
+.
+
+MessageId=0x0405
+Language=English
+cannot invoke %1!S! with provided arguments
+.
+
+MessageId=0x0406
+Language=English
+cannot redefine the symbol
+.
+
+MessageId=0x0407
+Language=English
+string constant is too long
+.
+
+MessageId=0x0480
+Language=English
+could not assemble
+.

--- a/zdc/src/zdc.mc
+++ b/zdc/src/zdc.mc
@@ -123,6 +123,11 @@ Language=English
 could not assemble
 .
 
+MessageId=0x0482
+Language=English
+undefined name
+.
+
 ; // ZDC messages
 
 MessageId=0x8000

--- a/zdc/src/zdc.mc
+++ b/zdc/src/zdc.mc
@@ -122,3 +122,17 @@ MessageId=0x0480
 Language=English
 could not assemble
 .
+
+; // ZDC messages
+
+MessageId=0x8000
+SymbolicName=MSG_ERROR
+Language=English
+error: 
+.
+
+MessageId=0x8001
+SymbolicName=MSG_NO_OUTPUT
+Language=English
+no output file name provided (argument -o)
+.

--- a/zdc/src/zdc.mc
+++ b/zdc/src/zdc.mc
@@ -113,6 +113,11 @@ Language=English
 string constant is too long
 .
 
+MessageId=0x0408
+Language=English
+invalid argument
+.
+
 MessageId=0x0480
 Language=English
 could not assemble

--- a/zdc/src/zdc.mc
+++ b/zdc/src/zdc.mc
@@ -80,17 +80,17 @@ unexpected character %1!u! in the emit directive
 
 MessageId=0x0401
 Language=English
-unexpected node
+unexpected '%1!S!'
 .
 
 MessageId=0x0402
 Language=English
-cannot %1!S! this pair of operands
+cannot %1!S! %2!S! and %3!S!
 .
 
 MessageId=0x0403
 Language=English
-cannot assign this pair of target and source
+cannot assign %1!S! to %2!S!
 .
 
 MessageId=0x0404
@@ -105,12 +105,12 @@ cannot invoke %1!S! with provided arguments
 
 MessageId=0x0406
 Language=English
-cannot redefine the symbol
+cannot redefine '%1!S!'
 .
 
 MessageId=0x0407
 Language=English
-string constant is too long
+string constant is %1!d! characters too long
 .
 
 MessageId=0x0408
@@ -120,12 +120,12 @@ invalid argument
 
 MessageId=0x0480
 Language=English
-could not assemble
+cannot assemble
 .
 
 MessageId=0x0482
 Language=English
-undefined name
+name '%1!S!' was never defined
 .
 
 ; // ZDC messages


### PR DESCRIPTION
ZD4:
- przechowuj położenie węzła i śledź je
- zaimplementuj `error_origin_traits`
- rozdziel błędy i asercje
- zwracaj informacje o błędzie w generatorze i procedurach wbudowanych
- zmień formatowanie błędów

DOS:
- obezwładnij `__umoddi3` i `__udivdi3` (rozmiar kodu wynikowego)