### PR TITLE
Optymalizuj rozmiar kompilatora

### DIFF
--- a/zdc/include/zd/error.hpp
+++ b/zdc/include/zd/error.hpp
@@ -89,16 +89,9 @@ class error
     }
 
   public:
-    error()
-        : _origin{0}, _ordinal{0}, _file{}, _line{0}, _column{0}, _argc{0},
-          _argv{nullptr}
-    {
-    }
+    error();
 
-    operator bool() const
-    {
-        return (0 == _origin) && (0 == _ordinal);
-    }
+    operator bool() const;
 
     template <typename Torigin,
               typename Traits = error_origin_traits<Torigin>,
@@ -130,13 +123,7 @@ class error
 
     error(const error &) = delete;
 
-    error(error &&that) noexcept
-        : _origin{that._origin}, _ordinal{that._ordinal},
-          _file{std::move(that._file)}, _line{that._line},
-          _column{that._column}, _argc{std::exchange(that._argc, 0)},
-          _argv{std::exchange(that._argv, nullptr)}
-    {
-    }
+    error(error &&that) noexcept;
 
     ~error();
 

--- a/zdc/include/zd/gen/x86_assembler.hpp
+++ b/zdc/include/zd/gen/x86_assembler.hpp
@@ -103,13 +103,7 @@ class x86_assembler
     cmp(const symbol_ref &left, uint16_t right);
 
     bool
-    cmp(mreg left, unsigned right);
-
-    bool
     dec(const symbol_ref &dst);
-
-    bool
-    inb();
 
     bool
     jb(const symbol_ref &target);
@@ -122,9 +116,6 @@ class x86_assembler
 
     bool
     jne(const symbol_ref &target);
-
-    bool
-    lodsb();
 
     bool
     mov(par::cpu_register dst, par::cpu_register src);
@@ -151,15 +142,6 @@ class x86_assembler
     mov(par::cpu_register dst, unsigned src);
 
     bool
-    nop();
-
-    bool
-    outb();
-
-    bool
-    pop(x86_segment seg);
-
-    bool
     pop(const symbol_ref &dst);
 
     bool
@@ -181,16 +163,10 @@ class x86_assembler
     add(par::cpu_register dst, unsigned src);
 
     bool
-    add(par::cpu_register dst, par::cpu_register src);
-
-    bool
     add(const symbol_ref &dst, unsigned src);
 
     bool
     inc(par::cpu_register reg);
-
-    bool
-    inc(mreg reg);
 
     bool
     inc(const symbol_ref &dst);
@@ -200,9 +176,6 @@ class x86_assembler
 
     bool
     ret();
-
-    bool
-    shr(par::cpu_register reg, par::cpu_register cl);
 
     bool
     sub(const symbol_ref &dst, unsigned src);

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -11,29 +11,6 @@ namespace zd
 namespace gen
 {
 
-template <typename T> struct member_function_traits;
-
-template <typename R, typename C, typename... Args>
-struct member_function_traits<R (C::*)(Args...)>
-{
-    using return_type = R;
-    using class_type = C;
-    using arg_types = std::tuple<Args...>;
-    static constexpr std::size_t arg_count = sizeof...(Args);
-};
-
-template <typename R, typename C, typename... Args>
-struct member_function_traits<R (C::*)(Args...) const>
-{
-    using return_type = R;
-    using class_type = C;
-    using arg_types = std::tuple<Args...>;
-    static constexpr std::size_t arg_count = sizeof...(Args);
-};
-
-template <typename T>
-using extract_args = typename member_function_traits<T>::arg_types;
-
 struct zd4_byte
 {
     const par::node *node;
@@ -42,20 +19,11 @@ struct zd4_byte
     par::cpu_register reg;
     uint8_t           val;
 
-    zd4_byte(symbol *sym_, const par::node *node_ = nullptr)
-        : sym{sym_}, reg{par::cpu_register::invalid}, val{}, node{node_}
-    {
-    }
+    zd4_byte(symbol *sym_, const par::node *node_ = nullptr);
 
-    zd4_byte(par::cpu_register reg_, const par::node *node_ = nullptr)
-        : sym{nullptr}, reg{reg_}, val{}, node{node_}
-    {
-    }
+    zd4_byte(par::cpu_register reg_, const par::node *node_ = nullptr);
 
-    zd4_byte(uint8_t val_, const par::node *node_ = nullptr)
-        : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}, node{node_}
-    {
-    }
+    zd4_byte(uint8_t val_, const par::node *node_ = nullptr);
 
     bool
     load(x86_assembler &as, par::cpu_register dst) const;
@@ -67,10 +35,7 @@ struct zd4_file
 
     uint16_t val;
 
-    zd4_file(uint16_t val_, const par::node *node_ = nullptr)
-        : val{val_}, node{node_}
-    {
-    }
+    zd4_file(uint16_t val_, const par::node *node_ = nullptr);
 
     bool
     load(x86_assembler &as, par::cpu_register dst) const;
@@ -83,15 +48,9 @@ struct zd4_text
     const symbol  *sym;
     const ustring *val;
 
-    zd4_text(const symbol *sym_, const par::node *node_ = nullptr)
-        : sym{sym_}, val{nullptr}, node{node_}
-    {
-    }
+    zd4_text(const symbol *sym_, const par::node *node_ = nullptr);
 
-    zd4_text(const ustring *val_, const par::node *node_ = nullptr)
-        : sym{nullptr}, val{val_}, node{node_}
-    {
-    }
+    zd4_text(const ustring *val_, const par::node *node_ = nullptr);
 
     bool
     load(x86_assembler    &as,
@@ -110,20 +69,11 @@ struct zd4_word
     par::cpu_register reg;
     uint16_t          val;
 
-    zd4_word(const symbol *sym_, const par::node *node_ = nullptr)
-        : sym{sym_}, reg{par::cpu_register::invalid}, val{}, node{node_}
-    {
-    }
+    zd4_word(const symbol *sym_, const par::node *node_ = nullptr);
 
-    zd4_word(par::cpu_register reg_, const par::node *node_ = nullptr)
-        : sym{nullptr}, reg{reg_}, val{}, node{node_}
-    {
-    }
+    zd4_word(par::cpu_register reg_, const par::node *node_ = nullptr);
 
-    zd4_word(uint16_t val_, const par::node *node_ = nullptr)
-        : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}, node{node_}
-    {
-    }
+    zd4_word(uint16_t val_, const par::node *node_ = nullptr);
 
     bool
     load(x86_assembler &as, par::cpu_register dst) const;
@@ -327,21 +277,6 @@ class zd4_builtins
 
     std::pair<unsigned, unsigned>
     emit(const uint8_t *code, unsigned size);
-
-    template <size_t N>
-    void
-    emit(const uint8_t (&code)[N])
-    {
-        emit(code, N);
-    }
-
-#ifdef __ia16__
-    void
-    emit(std::initializer_list<uint8_t> list)
-    {
-        emit(list.begin(), list.size());
-    }
-#endif
 
     symbol *
     get_procedure(const ustring &name, const uint8_t *code, unsigned size);

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -325,6 +325,24 @@ class zd4_builtins
     error
     ZPortu();
 
+    std::pair<unsigned, unsigned>
+    emit(const uint8_t *code, unsigned size);
+
+    template <size_t N>
+    void
+    emit(const uint8_t (&code)[N])
+    {
+        emit(code, N);
+    }
+
+#ifdef __ia16__
+    void
+    emit(std::initializer_list<uint8_t> list)
+    {
+        emit(list.begin(), list.size());
+    }
+#endif
+
     symbol *
     get_procedure(const ustring &name, const uint8_t *code, unsigned size);
 

--- a/zdc/include/zd/gen/zd4_builtins.hpp
+++ b/zdc/include/zd/gen/zd4_builtins.hpp
@@ -11,10 +11,13 @@ namespace zd
 namespace gen
 {
 
-struct zd4_byte
+struct zd4_arg
 {
     const par::node *node;
+};
 
+struct zd4_byte : public zd4_arg
+{
     const symbol     *sym;
     par::cpu_register reg;
     uint8_t           val;
@@ -29,10 +32,8 @@ struct zd4_byte
     load(x86_assembler &as, par::cpu_register dst) const;
 };
 
-struct zd4_file
+struct zd4_file : public zd4_arg
 {
-    const par::node *node;
-
     uint16_t val;
 
     zd4_file(uint16_t val_, const par::node *node_ = nullptr);
@@ -41,10 +42,8 @@ struct zd4_file
     load(x86_assembler &as, par::cpu_register dst) const;
 };
 
-struct zd4_text
+struct zd4_text : public zd4_arg
 {
-    const par::node *node;
-
     const symbol  *sym;
     const ustring *val;
 
@@ -61,10 +60,8 @@ struct zd4_text
     loadd(x86_assembler &as, par::cpu_register dst) const;
 };
 
-struct zd4_word
+struct zd4_word : public zd4_arg
 {
-    const par::node *node;
-
     const symbol     *sym;
     par::cpu_register reg;
     uint16_t          val;

--- a/zdc/include/zd/text/pl_string.hpp
+++ b/zdc/include/zd/text/pl_string.hpp
@@ -16,9 +16,17 @@ pl_toascii(int codepoint);
 bool
 pl_streqi(const ustring &left, const ustring &right);
 
+// Check equality of two Polish C strings, ignore case
+bool
+pl_streqi(const char *left, const char *right);
+
 // Check equality of two Polish strings, ignore diacritics and case
 bool
 pl_streqai(const ustring &left, const ustring &right);
+
+// Check equality of two Polish C strings, ignore diacritics and case
+bool
+pl_streqai(const char *left, const char *right);
 
 } // namespace text
 

--- a/zdc/src/zd/error.cpp
+++ b/zdc/src/zd/error.cpp
@@ -2,6 +2,20 @@
 
 using namespace zd;
 
+error::error()
+    : _origin{0}, _ordinal{0}, _file{}, _line{0}, _column{0}, _argc{0},
+      _argv{nullptr}
+{
+}
+
+error::error(error &&that) noexcept
+    : _origin{that._origin}, _ordinal{that._ordinal},
+      _file{std::move(that._file)}, _line{that._line}, _column{that._column},
+      _argc{std::exchange(that._argc, 0)},
+      _argv{std::exchange(that._argv, nullptr)}
+{
+}
+
 error::~error()
 {
     if (!_argv)
@@ -22,6 +36,11 @@ error::~error()
     // Destroy the buffer
     delete[] _argv;
     _argv = nullptr;
+}
+
+error::operator bool() const
+{
+    return (0 == _origin) && (0 == _ordinal);
 }
 
 error &

--- a/zdc/src/zd/gen/CMakeLists.txt
+++ b/zdc/src/zd/gen/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(zdc PRIVATE text_generator.cpp)
 target_sources(zdc PRIVATE x86_assembler.cpp)
-target_sources(zdc PRIVATE zd4_builtins.cpp)
 target_sources(zdc PRIVATE zd4_generator.cpp)
 target_sources(zdc PRIVATE zd4_section.cpp)
+
+add_subdirectory(zd4_builtins)

--- a/zdc/src/zd/gen/x86_assembler.cpp
+++ b/zdc/src/zd/gen/x86_assembler.cpp
@@ -221,34 +221,11 @@ x86_assembler::cmp(par::cpu_register left, const symbol_ref &right)
 }
 
 bool
-x86_assembler::cmp(mreg left, unsigned right)
-{
-    if (sizeof(uint16_t) == _reg_size(left.reg))
-    {
-        ASM_REQUIRE(UINT16_MAX >= right);
-
-        _code->emit_byte(CMP_rm16_imm16);
-        _code->emit_byte(ModRM(left.encode(), 7));
-        _code->emit_word(right);
-        return true;
-    }
-
-    return false;
-}
-
-bool
 x86_assembler::dec(const symbol_ref &dst)
 {
     _code->emit_byte(DEC_rm16);
     _code->emit_byte(ModRM(ModRM_disp16, 1));
     _code->emit_ref({dst.sym.address, dst.sym.section, dst.off});
-    return true;
-}
-
-bool
-x86_assembler::inb()
-{
-    _code->emit_byte(IN_AL_DX);
     return true;
 }
 
@@ -292,13 +269,6 @@ x86_assembler::jne(const symbol_ref &target)
 {
     _code->emit_word(JNE_rel16);
     _code->emit_ref({target.sym.address, target.sym.section, -2, true});
-    return true;
-}
-
-bool
-x86_assembler::lodsb()
-{
-    _code->emit_byte(LODS_m8);
     return true;
 }
 
@@ -413,49 +383,6 @@ x86_assembler::mov(par::cpu_register dst, unsigned src)
 }
 
 bool
-x86_assembler::nop()
-{
-    _code->emit_byte(NOP);
-    return true;
-}
-
-bool
-x86_assembler::outb()
-{
-    _code->emit_byte(OUT_DX_AL);
-    return true;
-}
-
-bool
-zd::gen::x86_assembler::pop(x86_segment seg)
-{
-    switch (seg)
-    {
-    case x86_segment::ds:
-        _code->emit_byte(POP_DS);
-        return true;
-
-    case x86_segment::es:
-        _code->emit_byte(POP_ES);
-        return true;
-
-    case x86_segment::ss:
-        _code->emit_byte(POP_SS);
-        return true;
-
-    case x86_segment::fs:
-        _code->emit_word(POP_FS);
-        return true;
-
-    case x86_segment::gs:
-        _code->emit_word(POP_GS);
-        return true;
-    }
-
-    return false;
-}
-
-bool
 x86_assembler::pop(const symbol_ref &dst)
 {
     _code->emit_byte(POP_m16);
@@ -550,17 +477,6 @@ x86_assembler::add(par::cpu_register dst, unsigned src)
 }
 
 bool
-x86_assembler::add(par::cpu_register dst, par::cpu_register src)
-{
-    ASM_REQUIRE(_reg_size(dst) == _reg_size(src));
-    ASM_REQUIRE(sizeof(uint16_t) == _reg_size(dst));
-
-    _code->emit_byte(ADD_r16_rm16);
-    _code->emit_byte(ModRM(_to_mode(src), _to_regopcode(dst)));
-    return true;
-}
-
-bool
 x86_assembler::add(const symbol_ref &dst, unsigned src)
 {
     _code->emit_byte(ADD_rm16_imm16);
@@ -581,14 +497,6 @@ x86_assembler::inc(par::cpu_register reg)
     }
 
     _code->emit_byte(INC_r16 | _to_regopcode(reg));
-    return true;
-}
-
-bool
-x86_assembler::inc(mreg reg)
-{
-    _code->emit_byte(INC_rm16);
-    _code->emit_byte(ModRM(reg.encode(), 0));
     return true;
 }
 
@@ -616,16 +524,6 @@ bool
 x86_assembler::ret()
 {
     _code->emit_byte(RET_near);
-    return true;
-}
-
-bool
-x86_assembler::shr(par::cpu_register reg, par::cpu_register cl)
-{
-    ASM_REQUIRE(cpu_register::cl == cl);
-
-    _code->emit_byte(SHR_rm16_CL);
-    _code->emit_byte(ModRM(_to_mode(reg), 5));
     return true;
 }
 

--- a/zdc/src/zd/gen/zd4_builtins.cpp
+++ b/zdc/src/zd/gen/zd4_builtins.cpp
@@ -845,8 +845,14 @@ _matches_args(const char *signature, const node_list &args)
     return true;
 }
 
+static bool
+_matches(const char *signature, const ustring &name, const node_list &args)
+{
+    return _matches_name(signature, name) && _matches_args(signature, args);
+}
+
 template <typename T>
-T
+static T
 get_arg(zd4_builtins *this_, node &arg) = delete;
 
 template <>
@@ -921,16 +927,16 @@ get_arg<zd4_word>(zd4_builtins *this_, node &arg)
     return 0xFFFF;
 }
 
-error
+static error
 invoke(zd4_builtins *this_, error (zd4_builtins::*mfp)(), const node_list &args)
 {
     return (this_->*mfp)();
 }
 
 template <typename Arg1>
-error
-invoke(zd4_builtins *this_,
-       error (zd4_builtins::*mfp)(Arg1),
+static error
+invoke(zd4_builtins    *this_,
+       error            (zd4_builtins::*mfp)(Arg1),
        const node_list &args)
 {
     auto it = args.begin();
@@ -939,9 +945,9 @@ invoke(zd4_builtins *this_,
 }
 
 template <typename Arg1, typename Arg2>
-error
-invoke(zd4_builtins *this_,
-       error (zd4_builtins::*mfp)(Arg1, Arg2),
+static error
+invoke(zd4_builtins    *this_,
+       error            (zd4_builtins::*mfp)(Arg1, Arg2),
        const node_list &args)
 {
     auto it = args.begin();
@@ -951,9 +957,9 @@ invoke(zd4_builtins *this_,
 }
 
 template <typename Arg1, typename Arg2, typename Arg3>
-error
-invoke(zd4_builtins *this_,
-       error (zd4_builtins::*mfp)(Arg1, Arg2, Arg3),
+static error
+invoke(zd4_builtins    *this_,
+       error            (zd4_builtins::*mfp)(Arg1, Arg2, Arg3),
        const node_list &args)
 {
     auto it = args.begin();
@@ -966,8 +972,7 @@ invoke(zd4_builtins *this_,
 #define INVOKE_IF_MATCH(mf)                                                    \
     {                                                                          \
         auto __signature = #mf;                                                \
-        if (_matches_name(__signature, node.callee) &&                         \
-            _matches_args(__signature, node.arguments))                        \
+        if (_matches(__signature, node.callee, node.arguments))                \
         {                                                                      \
             return invoke(this, &zd4_builtins::mf, node.arguments);            \
         }                                                                      \

--- a/zdc/src/zd/gen/zd4_builtins/CMakeLists.txt
+++ b/zdc/src/zd/gen/zd4_builtins/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(zdc PRIVATE dispatch.cpp)
+target_sources(zdc PRIVATE procedures.cpp)
+target_sources(zdc PRIVATE types.cpp)

--- a/zdc/src/zd/gen/zd4_builtins/dispatch.cpp
+++ b/zdc/src/zd/gen/zd4_builtins/dispatch.cpp
@@ -1,0 +1,278 @@
+#include <zd/gen/zd4_builtins.hpp>
+#include <zd/text/pl_string.hpp>
+
+using namespace zd;
+using namespace zd::gen;
+using namespace zd::par;
+
+#define RETURN_IF_FALSE(expr)                                                  \
+    if (!(expr))                                                               \
+    {                                                                          \
+        return false;                                                          \
+    }
+
+static bool
+_matches_name(const char *signature, const ustring &str)
+{
+    ustring name{};
+    for (auto ch : ustring{signature})
+    {
+        if ('_' == ch)
+        {
+            break;
+        }
+
+        name.append(ch);
+    }
+
+    return text::pl_streqai(name, str);
+}
+
+static bool
+_matches_args(const char *signature, const node_list &args)
+{
+    auto arg_types = std::strchr(signature, '_');
+    if (!arg_types)
+    {
+        return args.empty();
+    }
+
+    arg_types++;
+    if (std::strlen(arg_types) != args.size())
+    {
+        return false;
+    }
+
+    for (auto &arg : args)
+    {
+        switch (*arg_types)
+        {
+        case 'b':
+        case 'w':
+            RETURN_IF_FALSE(
+                arg->is<number_node>() || arg->is<register_node>() ||
+                (arg->is<object_node>() &&
+                 (object_type::text != arg->as<object_node>()->type)));
+            break;
+
+        case 'f':
+            RETURN_IF_FALSE(
+                arg->is<subscript_node>() &&
+                arg->as<subscript_node>()->value->is<number_node>());
+            break;
+
+        case 't':
+            RETURN_IF_FALSE(
+                arg->is<string_node>() ||
+                (arg->is<object_node>() &&
+                 (object_type::text == arg->as<object_node>()->type)));
+            break;
+
+        case 'T':
+            RETURN_IF_FALSE(
+                arg->is<object_node>() &&
+                (object_type::text == arg->as<object_node>()->type));
+            break;
+
+        default:
+            assert(false && "unknown argument type");
+        }
+
+        arg_types++;
+    }
+
+    return true;
+}
+
+static bool
+_matches(const char *signature, const ustring &name, const node_list &args)
+{
+    return _matches_name(signature, name) && _matches_args(signature, args);
+}
+
+template <typename T>
+static T
+get_arg(zd4_builtins *this_, node &arg) = delete;
+
+template <>
+zd4_byte
+get_arg<zd4_byte>(zd4_builtins *this_, node &arg)
+{
+    if (arg.is<number_node>())
+    {
+        return zd4_byte(arg.as<number_node>()->value, &arg);
+    }
+
+    if (arg.is<register_node>())
+    {
+        return {arg.as<register_node>()->reg, &arg};
+    }
+
+    if (arg.is<object_node>())
+    {
+        return {&this_->gen.get_symbol(arg.as<object_node>()->name), &arg};
+    }
+
+    assert(false && "unexpected argument node type for a byte");
+    return 0xFF;
+}
+
+template <>
+zd4_file
+get_arg<zd4_file>(zd4_builtins *this_, node &arg)
+{
+    return zd4_file(arg.as<subscript_node>()->value->as<number_node>()->value,
+                    &arg);
+}
+
+template <>
+zd4_text
+get_arg<zd4_text>(zd4_builtins *this_, node &arg)
+{
+    if (arg.is<string_node>())
+    {
+        return {&arg.as<string_node>()->value, &arg};
+    }
+
+    if (arg.is<object_node>())
+    {
+        return {&this_->gen.get_symbol(arg.as<object_node>()->name), &arg};
+    }
+
+    assert(false && "unexpected argument node type for a text");
+    return static_cast<symbol *>(nullptr);
+}
+
+template <>
+zd4_word
+get_arg<zd4_word>(zd4_builtins *this_, node &arg)
+{
+    if (arg.is<number_node>())
+    {
+        return zd4_word(arg.as<number_node>()->value, &arg);
+    }
+
+    if (arg.is<register_node>())
+    {
+        return {arg.as<register_node>()->reg, &arg};
+    }
+
+    if (arg.is<object_node>())
+    {
+        return {&this_->gen.get_symbol(arg.as<object_node>()->name), &arg};
+    }
+
+    assert(false && "unexpected argument node type for a word");
+    return 0xFFFF;
+}
+
+static error
+invoke(zd4_builtins *this_, error (zd4_builtins::*mfp)(), const node_list &args)
+{
+    return (this_->*mfp)();
+}
+
+template <typename Arg1>
+static error
+invoke(zd4_builtins    *this_,
+       error            (zd4_builtins::*mfp)(Arg1),
+       const node_list &args)
+{
+    auto it = args.begin();
+    auto arg1 = get_arg<std::decay_t<Arg1>>(this_, **it);
+    return (this_->*mfp)(arg1);
+}
+
+template <typename Arg1, typename Arg2>
+static error
+invoke(zd4_builtins    *this_,
+       error            (zd4_builtins::*mfp)(Arg1, Arg2),
+       const node_list &args)
+{
+    auto it = args.begin();
+    auto arg1 = get_arg<std::decay_t<Arg1>>(this_, **(it++));
+    auto arg2 = get_arg<std::decay_t<Arg2>>(this_, **it);
+    return (this_->*mfp)(arg1, arg2);
+}
+
+template <typename Arg1, typename Arg2, typename Arg3>
+static error
+invoke(zd4_builtins    *this_,
+       error            (zd4_builtins::*mfp)(Arg1, Arg2, Arg3),
+       const node_list &args)
+{
+    auto it = args.begin();
+    auto arg1 = get_arg<std::decay_t<Arg1>>(this_, **(it++));
+    auto arg2 = get_arg<std::decay_t<Arg2>>(this_, **(it++));
+    auto arg3 = get_arg<std::decay_t<Arg3>>(this_, **it);
+    return (this_->*mfp)(arg1, arg2, arg3);
+}
+
+#define INVOKE_IF_MATCH(mf)                                                    \
+    {                                                                          \
+        auto __signature = #mf;                                                \
+        if (_matches(__signature, node.callee, node.arguments))                \
+        {                                                                      \
+            return invoke(this, &zd4_builtins::mf, node.arguments);            \
+        }                                                                      \
+    }
+
+error
+zd4_builtins::dispatch(const call_node &node)
+{
+    _node = &node;
+
+    INVOKE_IF_MATCH(Czekaj_w);
+    INVOKE_IF_MATCH(Czysc);
+    INVOKE_IF_MATCH(Czysc_b);
+    INVOKE_IF_MATCH(Czytaj_T);
+    INVOKE_IF_MATCH(DoPortu);
+    INVOKE_IF_MATCH(Klawisz);
+    INVOKE_IF_MATCH(Laduj);
+    INVOKE_IF_MATCH(Losowa16);
+    INVOKE_IF_MATCH(Losowa8);
+    INVOKE_IF_MATCH(Nic);
+    INVOKE_IF_MATCH(Otworz_ft);
+    INVOKE_IF_MATCH(Otworz_ftb);
+    INVOKE_IF_MATCH(Pisz);
+    INVOKE_IF_MATCH(Pisz_t);
+    INVOKE_IF_MATCH(Pisz_tt);
+    INVOKE_IF_MATCH(Pisz_f);
+    INVOKE_IF_MATCH(Pisz_ft);
+    INVOKE_IF_MATCH(Pisz_ftt);
+    INVOKE_IF_MATCH(Pisz_w);
+    INVOKE_IF_MATCH(Pisz_fw);
+    INVOKE_IF_MATCH(PiszL);
+    INVOKE_IF_MATCH(PiszL_t);
+    INVOKE_IF_MATCH(PiszL_tt);
+    INVOKE_IF_MATCH(PiszL_f);
+    INVOKE_IF_MATCH(PiszL_ft);
+    INVOKE_IF_MATCH(PiszL_ftt);
+    INVOKE_IF_MATCH(PiszL_w);
+    INVOKE_IF_MATCH(PiszL_fw);
+    INVOKE_IF_MATCH(Pisz8);
+    INVOKE_IF_MATCH(Pisz8_b);
+    INVOKE_IF_MATCH(Pisz8_t);
+    INVOKE_IF_MATCH(PiszZnak_b);
+    INVOKE_IF_MATCH(PiszZnak_bb);
+    INVOKE_IF_MATCH(PiszZnak_bbw);
+    INVOKE_IF_MATCH(Pozycja_bb);
+    INVOKE_IF_MATCH(PokazMysz);
+    INVOKE_IF_MATCH(Przerwanie_b);
+    INVOKE_IF_MATCH(Punkt_wwb);
+    INVOKE_IF_MATCH(StanPrzyciskow);
+    INVOKE_IF_MATCH(StanPrzyciskow_t);
+    INVOKE_IF_MATCH(Tryb_b);
+    INVOKE_IF_MATCH(TworzKatalog_t);
+    INVOKE_IF_MATCH(TworzPlik_t);
+    INVOKE_IF_MATCH(UkryjMysz);
+    INVOKE_IF_MATCH(UsunKatalog_t);
+    INVOKE_IF_MATCH(UsunPlik_t);
+    INVOKE_IF_MATCH(Zamknij_f);
+    INVOKE_IF_MATCH(ZmienKatalog_t);
+    INVOKE_IF_MATCH(ZmienNazwe_tt);
+    INVOKE_IF_MATCH(ZmienNazwe_t);
+    INVOKE_IF_MATCH(ZPortu);
+
+    return error{gen, zd4_generator::error_code::not_a_builtin};
+}

--- a/zdc/src/zd/gen/zd4_builtins/types.cpp
+++ b/zdc/src/zd/gen/zd4_builtins/types.cpp
@@ -1,0 +1,162 @@
+#include <zd/gen/zd4_builtins.hpp>
+
+using namespace zd;
+using namespace zd::gen;
+using namespace zd::par;
+
+#define RETURN_IF_FALSE(expr)                                                  \
+    if (!(expr))                                                               \
+    {                                                                          \
+        return false;                                                          \
+    }
+
+zd4_byte::zd4_byte(symbol *sym_, const par::node *node_)
+    : sym{sym_}, reg{par::cpu_register::invalid}, val{}, node{node_}
+{
+}
+
+zd4_byte::zd4_byte(par::cpu_register reg_, const par::node *node_)
+    : sym{nullptr}, reg{reg_}, val{}, node{node_}
+{
+}
+
+zd4_byte::zd4_byte(uint8_t val_, const par::node *node_)
+    : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}, node{node_}
+{
+}
+
+bool
+zd4_byte::load(x86_assembler &as, cpu_register dst) const
+{
+    if (sym)
+    {
+        return as.mov(cpu_register::si, *sym) &&
+               as.mov(dst, mreg{cpu_register::si});
+    }
+
+    if (cpu_register::invalid != reg)
+    {
+        if (reg == dst)
+        {
+            return true;
+        }
+
+        if (cpu_register_word == ((unsigned)reg & 0xFF00))
+        {
+            // TODO: warning
+            return as.mov(dst,
+                          static_cast<cpu_register>(((unsigned)reg & 0xFF) |
+                                                    cpu_register_lbyte));
+        }
+
+        return as.mov(dst, reg);
+    }
+
+    return as.mov(dst, val);
+}
+
+zd4_file::zd4_file(uint16_t val_, const par::node *node_)
+    : val{val_}, node{node_}
+{
+}
+
+bool
+zd4_file::load(x86_assembler &as, cpu_register dst) const
+{
+    return as.mov(dst, val);
+}
+
+zd4_text::zd4_text(const symbol *sym_, const par::node *node_)
+    : sym{sym_}, val{nullptr}, node{node_}
+{
+}
+
+zd4_text::zd4_text(const ustring *val_, const par::node *node_)
+    : sym{nullptr}, val{val_}, node{node_}
+{
+}
+
+bool
+zd4_text::load(x86_assembler    &as,
+               par::cpu_register dst_buffer,
+               par::cpu_register dst_size) const
+{
+    RETURN_IF_FALSE(cpu_register_word == ((unsigned)dst_buffer & 0xFF00));
+
+    if (sym)
+    {
+        if (cpu_register::invalid != dst_size)
+        {
+            RETURN_IF_FALSE(as.mov(cpu_register::si, {*sym, +1}));
+            RETURN_IF_FALSE(as.mov(dst_size, mreg{cpu_register::si}));
+        }
+        return as.mov(dst_buffer, {*sym, +2});
+    }
+
+    RETURN_IF_FALSE(val);
+    std::vector<char> data{};
+    data.resize(val->size() + 2);
+
+    auto ptr = val->encode(data.data(), text::encoding::ibm852);
+    *(ptr++) = 0;
+    *(ptr++) = '$';
+
+    RETURN_IF_FALSE(as.mov(dst_buffer, data));
+    if (cpu_register::invalid != dst_size)
+    {
+        RETURN_IF_FALSE(as.mov(dst_size, ptr - data.data() - 2));
+    }
+    return true;
+}
+
+bool
+zd4_text::loadd(x86_assembler &as, par::cpu_register dst) const
+{
+    RETURN_IF_FALSE(cpu_register_word == ((unsigned)dst & 0xFF00));
+    RETURN_IF_FALSE(val);
+
+    std::vector<char> data{};
+    data.resize(val->size() + 1);
+
+    auto ptr = val->encode(data.data(), text::encoding::ibm852);
+    *ptr = '$';
+
+    return as.mov(dst, data);
+}
+
+zd4_word::zd4_word(const symbol *sym_, const par::node *node_)
+    : sym{sym_}, reg{par::cpu_register::invalid}, val{}, node{node_}
+{
+}
+
+zd4_word::zd4_word(par::cpu_register reg_, const par::node *node_)
+    : sym{nullptr}, reg{reg_}, val{}, node{node_}
+{
+}
+
+zd4_word::zd4_word(uint16_t val_, const par::node *node_)
+    : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}, node{node_}
+{
+}
+
+bool
+zd4_word::load(x86_assembler &as, cpu_register dst) const
+{
+    if (sym)
+    {
+        return as.mov(cpu_register::si, *sym) &&
+               as.mov(dst, mreg{cpu_register::si});
+    }
+
+    if (cpu_register::invalid != reg)
+    {
+        if (reg == dst)
+        {
+            return true;
+        }
+
+        return as.mov(dst, reg);
+    }
+
+    return as.mov(dst, val);
+}

--- a/zdc/src/zd/gen/zd4_builtins/types.cpp
+++ b/zdc/src/zd/gen/zd4_builtins/types.cpp
@@ -11,17 +11,17 @@ using namespace zd::par;
     }
 
 zd4_byte::zd4_byte(symbol *sym_, const par::node *node_)
-    : sym{sym_}, reg{par::cpu_register::invalid}, val{}, node{node_}
+    : zd4_arg{node_}, sym{sym_}, reg{par::cpu_register::invalid}, val{}
 {
 }
 
 zd4_byte::zd4_byte(par::cpu_register reg_, const par::node *node_)
-    : sym{nullptr}, reg{reg_}, val{}, node{node_}
+    : zd4_arg{node_}, sym{nullptr}, reg{reg_}, val{}
 {
 }
 
 zd4_byte::zd4_byte(uint8_t val_, const par::node *node_)
-    : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}, node{node_}
+    : zd4_arg{node_}, sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}
 {
 }
 
@@ -56,7 +56,7 @@ zd4_byte::load(x86_assembler &as, cpu_register dst) const
 }
 
 zd4_file::zd4_file(uint16_t val_, const par::node *node_)
-    : val{val_}, node{node_}
+    : zd4_arg{node_}, val{val_}
 {
 }
 
@@ -67,12 +67,12 @@ zd4_file::load(x86_assembler &as, cpu_register dst) const
 }
 
 zd4_text::zd4_text(const symbol *sym_, const par::node *node_)
-    : sym{sym_}, val{nullptr}, node{node_}
+    : zd4_arg{node_}, sym{sym_}, val{nullptr}
 {
 }
 
 zd4_text::zd4_text(const ustring *val_, const par::node *node_)
-    : sym{nullptr}, val{val_}, node{node_}
+    : zd4_arg{node_}, sym{nullptr}, val{val_}
 {
 }
 
@@ -125,17 +125,17 @@ zd4_text::loadd(x86_assembler &as, par::cpu_register dst) const
 }
 
 zd4_word::zd4_word(const symbol *sym_, const par::node *node_)
-    : sym{sym_}, reg{par::cpu_register::invalid}, val{}, node{node_}
+    : zd4_arg{node_}, sym{sym_}, reg{par::cpu_register::invalid}, val{}
 {
 }
 
 zd4_word::zd4_word(par::cpu_register reg_, const par::node *node_)
-    : sym{nullptr}, reg{reg_}, val{}, node{node_}
+    : zd4_arg{node_}, sym{nullptr}, reg{reg_}, val{}
 {
 }
 
 zd4_word::zd4_word(uint16_t val_, const par::node *node_)
-    : sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}, node{node_}
+    : zd4_arg{node_}, sym{nullptr}, reg{par::cpu_register::invalid}, val{val_}
 {
 }
 

--- a/zdc/src/zd/text/pl_string.cpp
+++ b/zdc/src/zd/text/pl_string.cpp
@@ -59,34 +59,57 @@ _load_codepoint(const char *&ptr, int &codepoint)
 bool
 zd::text::pl_streqi(const ustring &left, const ustring &right)
 {
-    return std::equal(left.begin(), left.end(), right.begin(), right.end(),
-                      [](int a, int b) -> bool {
-                          if (isascii(a) && isascii(b))
-                          {
-                              return std::toupper(a) == std::toupper(b);
-                          }
+    return pl_streqi(left.data(), right.data());
+}
 
-                          return a == b;
-                      });
+bool
+zd::text::pl_streqi(const char *left, const char *right)
+{
+    while (*left && *right)
+    {
+        if (isascii(*left) && isascii(*right))
+                          {
+            if (std::toupper(*left) == std::toupper(*right))
+            {
+                return false;
+                          }
+        }
+        else if (*left != *right)
+        {
+            return false;
+        }
+
+        left++;
+        right++;
+    }
+
+    if ((0 != *left) || (0 != *right))
+    {
     return false;
+    }
+
+    return true;
 }
 
 bool
 zd::text::pl_streqai(const ustring &left, const ustring &right)
 {
-    auto ptr_left = left.data();
-    auto ptr_right = right.data();
+    return pl_streqai(left.data(), right.data());
+}
 
-    while (*ptr_left && *ptr_right)
+bool
+zd::text::pl_streqai(const char *left, const char *right)
+{
+    while (*left && *right)
     {
         int codepoint_left, codepoint_right;
 
-        if (!_load_codepoint(ptr_left, codepoint_left))
+        if (!_load_codepoint(left, codepoint_left))
         {
             return false;
         }
 
-        if (!_load_codepoint(ptr_right, codepoint_right))
+        if (!_load_codepoint(right, codepoint_right))
         {
             return false;
         }
@@ -98,7 +121,7 @@ zd::text::pl_streqai(const ustring &left, const ustring &right)
         }
     }
 
-    if ((0 != *ptr_left) || (0 != *ptr_right))
+    if ((0 != *left) || (0 != *right))
     {
         return false;
     }

--- a/zdc/src/zd/text/pl_string.cpp
+++ b/zdc/src/zd/text/pl_string.cpp
@@ -56,6 +56,32 @@ _load_codepoint(const char *&ptr, int &codepoint)
     return true;
 }
 
+static int
+_to_upper(int codepoint)
+{
+    if (zd::text::isascii(codepoint))
+    {
+        return std::toupper(codepoint);
+    }
+
+    auto mapping =
+        std::find_if(std::begin(POLISH_LETTERS), std::end(POLISH_LETTERS),
+                     [codepoint](const _code_mapping &cm) {
+                         return cm.codepoint == codepoint;
+                     });
+    if (std::end(POLISH_LETTERS) == mapping)
+    {
+        return codepoint;
+    }
+
+    if (std::isupper(mapping->ascii))
+    {
+        return codepoint;
+    }
+
+    return mapping[-1].codepoint;
+}
+
 bool
 zd::text::pl_streqi(const ustring &left, const ustring &right)
 {
@@ -68,11 +94,11 @@ zd::text::pl_streqi(const char *left, const char *right)
     while (*left && *right)
     {
         if (isascii(*left) && isascii(*right))
-                          {
-            if (std::toupper(*left) == std::toupper(*right))
+        {
+            if (_to_upper(*left) != _to_upper(*right))
             {
                 return false;
-                          }
+            }
         }
         else if (*left != *right)
         {
@@ -85,7 +111,7 @@ zd::text::pl_streqi(const char *left, const char *right)
 
     if ((0 != *left) || (0 != *right))
     {
-    return false;
+        return false;
     }
 
     return true;


### PR DESCRIPTION
Zmniejsz rozmiar binarnego pliku kompilatora.

Ogólne:
- przenieś implementację konstruktorów klasy `error`
- porównuj polskie C-stringi
- napraw porównanie polskich ciągów bez rozróżnienia wielkości liter

Parser:
- rozróżniaj typy węzłów za pomocą tagów po DOS-em

ZD4:
- nie asembluj niezmiennych fragmentów
- uprość i zoptymalizuj dopasowanie procedur wbudowanych
- podziel klasę `zd4_builtins` na pliki
- usuń nieużywane metody asemblera